### PR TITLE
Crafted Item & SimC Import additions

### DIFF
--- a/src/General/Modules/TopGear/ItemSet.js
+++ b/src/General/Modules/TopGear/ItemSet.js
@@ -146,7 +146,11 @@ class ItemSet {
     } else if (this.uniques["vault"] && this.uniques["vault"] > 1) {
       //console.log("SET NOT VIABLE - Vault");
       return false;
-    } else {
+    } else if (this.uniques["crafted"] && this.uniques["crafted"] > 1) {
+      //console.log("SET NOT VIABLE - 230 Crafted Items");
+      return false;
+    }
+     else {
       return true;
     }
   }

--- a/src/General/Modules/UpgradeFinder/UpgradeFinderEngine.js
+++ b/src/General/Modules/UpgradeFinder/UpgradeFinderEngine.js
@@ -91,12 +91,12 @@ export function runUpgradeFinder(player, contentType, currentLanguage, playerSet
   //buildWepCombos(player, false, false); // TODO: DEL
 
   const baseHPS = player.getHPS(contentType);
+  userSettings.dominationSockets = "Upgrade Finder";
   const baseSet = runTopGear(baseItemList, wepList, player, contentType, baseHPS, currentLanguage, userSettings, castModel);
   const baseScore = baseSet.itemSet.hardScore;
 
-  //console.log(wepList);
-  //console.log(baseItemList);
-  userSettings.dominationSockets = "Upgrade Finder";
+
+  
   const itemPoss = buildItemPossibilities(player, contentType, playerSettings);
 
   for (var x = 0; x < itemPoss.length; x++) {

--- a/src/General/Modules/UpgradeFinder/UpgradeFinderResults.js
+++ b/src/General/Modules/UpgradeFinder/UpgradeFinderResults.js
@@ -192,7 +192,6 @@ export default function UpgradeFinderResults(props) {
   const result = props.itemSelection;
   const itemList = result.itemSet;
   const itemDifferentials = result.differentials;
-
   const gameType = useSelector((state) => state.gameType);
 
   itemList.sort((a, b) => (getDifferentialByID(itemDifferentials, a.id, a.level) < getDifferentialByID(itemDifferentials, b.id, b.level) ? 1 : -1));

--- a/src/Retail/Engine/EffectFormulas/Druid/DruidConduitFormulas.js
+++ b/src/Retail/Engine/EffectFormulas/Druid/DruidConduitFormulas.js
@@ -77,9 +77,9 @@ export const getDruidConduit = (conduitID, player, contentType, conduitLevel) =>
 
   // Well-Honed Instincts
   else if (conduitID === 340553) {
-    const traitBonusList = [135, 123, 113, 104, 97, 90, 84, 79, 75, 71, 67, 64, 61, 58, 56]; // This is actually the cooldown on the effect. TODO: Improve the precision of the number. It's an odd one.
+    const traitBonusList = [135, 123, 113, 104, 97, 90, 84, 79, 75, 71, 67, 64, 61, 58, 56]; //
     const traitBonus = traitBonusList[conduitLevel]
-    const timeSpentOnCooldown = 0.6;
+    const timeSpentOnCooldown = 0.7;
     const frenziedRegenHealing = player.getHealth() * 0.24;
 
     bonus_stats.HPS = (frenziedRegenHealing * timeSpentOnCooldown) / traitBonus;

--- a/src/Retail/Engine/EffectFormulas/EffectEngine.js
+++ b/src/Retail/Engine/EffectFormulas/EffectEngine.js
@@ -157,7 +157,7 @@ export function getConduitFormula(effectID, player, contentType, itemLevel = 145
   if (effectID === 357902) {
     // % intellect increase when healed by another player. 15s duration, 30s cooldown.
     const percentInc = 0.02 + conduitRank * 0.002;
-    const uptime = contentType == "Raid" ? 0.4 : 0;
+    const uptime = contentType == "Raid" ? 0.45 : 0;
     const intGain = percentInc * player.getInt() * uptime;
     bonus_stats.HPS = intGain / player.getInt() * (player.getHPS(contentType) * 0.75); // Remove this 0.75 modifier when the cast models update.
   }

--- a/src/Retail/Engine/EffectFormulas/EffectEngine.js
+++ b/src/Retail/Engine/EffectFormulas/EffectEngine.js
@@ -162,7 +162,7 @@ export function getConduitFormula(effectID, player, contentType, itemLevel = 145
     bonus_stats.HPS = intGain / player.getInt() * (player.getHPS(contentType) * 0.75); // Remove this 0.75 modifier when the cast models update.
   }
   else if (effectID === 357888) {
-    // Small heal based on your max health whenever you take damage. 10s cooldown. The heal on this is currently 10x it's tooltip value.
+    // Small heal based on your max health whenever you take damage. 10s cooldown.
     const percHealing = (0.25 + conduitRank * 0.025) / 100 * 10;
     const ppm = 60 / 10 * 0.7; // Condensed Anima Sphere notably does not proc off a significant number of abilities.
     const expectedOverhealing = 0.32;

--- a/src/Retail/Engine/EffectFormulas/Generic/GenericEffectFormulas.js
+++ b/src/Retail/Engine/EffectFormulas/Generic/GenericEffectFormulas.js
@@ -29,9 +29,11 @@ export function getDominationGemEffect(effectName, player, contentType, rank) {
 
   if (effectName === "Shard of Zed") {
     const effect = activeEffect.effects[0];
+    const expectedOverhealing = 0.4;
+    const dpsWastage = 0.3;
     const throughput = Math.round(getProcessedValue(effect.coefficient[rank], effect.table, 0, 1, false)) * effect.ppm * 5 * effect.expectedTargets[contentType] / 60
-    bonus_stats.hps = throughput;
-    bonus_stats.dps = throughput;
+    bonus_stats.hps = throughput * (1 - expectedOverhealing);
+    bonus_stats.dps = throughput * (1 - dpsWastage);
 
   }
   else if (effectName === "Shard of Rev") {

--- a/src/Retail/Engine/SimCImport/SimCImportEngine.js
+++ b/src/Retail/Engine/SimCImport/SimCImportEngine.js
@@ -216,6 +216,7 @@ function processItem(line, player, contentType, type) {
   let itemEquipped = !line.includes("#");
   let bonusIDS = "";
   let domGemID = 0;
+  let uniqueTag = "";
   
 
   // Build out our item information.
@@ -309,6 +310,8 @@ function processItem(line, player, contentType, type) {
     else if (bonus_id === "6648" && craftedStats.length === 0) missiveStats.push("mastery");
     else if (bonus_id === "6649" && craftedStats.length === 0) missiveStats.push("haste");
     else if (bonus_id === "6650" && craftedStats.length === 0) missiveStats.push("versatility");
+
+    if (bonus_id === "7461") uniqueTag = "crafted";
   }
   if (craftedStats.length !== 0) itemBonusStats = getSecondaryAllocationAtItemLevel(itemLevel, itemSlot, craftedStats);
   if (levelOverride !== 0) itemLevel = Math.min(499, levelOverride);
@@ -341,6 +344,7 @@ function processItem(line, player, contentType, type) {
     item.domGemID = parseInt(domGemID);
     if (item.effect.type && item.effect.type === "spec legendary") item.uniqueEquip = "legendary";
     else if (item.vaultItem) item.uniqueEquip = "vault";
+    else item.uniqueEquip = uniqueTag;
     item.softScore = scoreItem(item, player, contentType);
 
     //console.log("Adding Item: " + item.id + " in slot: " + itemSlot);

--- a/src/Retail/Engine/SimCImport/SimCImportEngine.js
+++ b/src/Retail/Engine/SimCImport/SimCImportEngine.js
@@ -306,11 +306,26 @@ function processItem(line, player, contentType, type) {
         //console.log("Legendary detected" + JSON.stringify(itemEffect));
       }
     }
-    // Missives
-    else if (bonus_id === "6647" && craftedStats.length === 0) missiveStats.push("crit");
-    else if (bonus_id === "6648" && craftedStats.length === 0) missiveStats.push("mastery");
-    else if (bonus_id === "6649" && craftedStats.length === 0) missiveStats.push("haste");
-    else if (bonus_id === "6650" && craftedStats.length === 0) missiveStats.push("versatility");
+    // Missives.
+    // Missives are on every legendary, and are annoyingly also on some crafted items.
+    // Crafted items will either have a missive ID and an INCORRECT crafted_stats id or just a CORRECT crafted_stats ID.
+    // Therefore if a missive ID is present, we need to kill the crafted_stats value.
+    else if (bonus_id === "6647") {
+      missiveStats.push("crit");
+      craftedStats = "";
+    }
+    else if (bonus_id === "6648") {
+      missiveStats.push("mastery");
+      craftedStats = "";
+    }
+    else if (bonus_id === "6649") {
+      missiveStats.push("haste");
+      craftedStats = "";
+    }
+    else if (bonus_id === "6650") {
+      missiveStats.push("versatility");
+      craftedStats = "";
+    }
 
     if (bonus_id === "7461") uniqueTag = "crafted";
   }

--- a/src/Retail/Engine/SimCImport/SimCImportEngine.js
+++ b/src/Retail/Engine/SimCImport/SimCImportEngine.js
@@ -30,8 +30,9 @@ export function runSimC(simCInput, player, contentType, setErrorMessage, snackHa
             We should take care that we never use the Name tags in the string.
     */
 
-    let vaultItems = lines.indexOf("### Weekly Reward Choices") !== -1 ? lines.indexOf("### Weekly Reward Choices") : lines.length;
-    let linkedItems = lines.indexOf("### Linked gear") !== -1 ? lines.indexOf("### Linked gear") : 0;
+    
+    let linkedItems = lines.indexOf("### Linked gear") !== -1 ? lines.indexOf("### Linked gear") : lines.length;
+    let vaultItems = lines.indexOf("### Weekly Reward Choices") !== -1 ? lines.indexOf("### Weekly Reward Choices") : linkedItems;
 
     // We only use the covenant variable to expand weapon tokens. Setting a default is a better approach than showing none if it's missing,
     // given the weapons and offhands are near identical anyway.
@@ -42,7 +43,7 @@ export function runSimC(simCInput, player, contentType, setErrorMessage, snackHa
 
     for (var i = 8; i < lines.length; i++) {
       let line = lines[i];
-      let type = i > vaultItems || i < linkedItems ? "Vault" : "Regular";
+      let type = i > vaultItems && i < linkedItems ? "Vault" : "Regular";
       // If our line doesn't include an item ID, skip it.
       if (line.includes("id=")) {
         if (line.includes("unknown")) {


### PR DESCRIPTION
- Added Handling for rare crafted items that use Missive IDs instead of crafted_stats.
- Added restriction for 1 crafted item per top gear set.
- Added support for SimC "Linked Items"