### PR TITLE
Sequence improvements

### DIFF
--- a/src/General/Modules/Player/DiscPriest/DiscPriestRamps.js
+++ b/src/General/Modules/Player/DiscPriest/DiscPriestRamps.js
@@ -464,7 +464,7 @@ export const runCastSequence = (sequence, stats, settings = {}, talents = {}) =>
             spell.coeff = spell.coeff * partialTickPercentage;
             
             if (buff.buffType === "damage") runDamage(state, spell, buff.name, atonementApp);
-            else if (buff.buffType === "healing") runHeal(state, spell, buff.name)
+            else if (buff.buffType === "heal") runHeal(state, spell, buff.name)
         })
 
         // Remove any buffs that have expired. Note that we call this after we handle partial ticks. 
@@ -524,7 +524,7 @@ export const runCastSequence = (sequence, stats, settings = {}, talents = {}) =>
                     else if (spell.buffType === "statsMult") {
                         state.activeBuffs.push({name: spellName, expiration: state.t + spell.buffDuration, buffType: "statsMult", value: spell.value, stat: spell.stat});
                     }
-                    else if (spell.buffType === "damage" || spell.buffType === "healing") {     
+                    else if (spell.buffType === "damage" || spell.buffType === "heal") {     
                         const newBuff = {name: spellName, buffType: spell.buffType, attSpell: spell,
                             tickRate: spell.tickRate, canPartialTick: spell.canPartialTick, next: state.t + (spell.tickRate / getHaste(state.currentStats))}
 

--- a/src/General/Modules/SequenceGenerator/Sequence.css
+++ b/src/General/Modules/SequenceGenerator/Sequence.css
@@ -1,0 +1,9 @@
+img.icon {
+  height: 40px;
+  width: 40px;
+  border-radius: 4px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ff8000;
+  margin-right: 0px;
+}

--- a/src/General/Modules/SequenceGenerator/SequenceGenerator.js
+++ b/src/General/Modules/SequenceGenerator/SequenceGenerator.js
@@ -102,6 +102,16 @@ export default function SequenceGenerator(props) {
     updateSequence([...seq, spell]);
   };
 
+  const removeSpellAtIndex = (index, e = null) => {
+    if (!!e) {
+      e.preventDefault();
+    }
+
+    const editSeq = [...seq];
+    editSeq.splice(index, 1);
+    updateSequence(editSeq);
+  }
+
   const insertSpellAtIndex = (spell, index) => {
     const editSeq = [
       ...seq.slice(0, index),
@@ -225,8 +235,8 @@ export default function SequenceGenerator(props) {
                             </Grid> */}
 
                       {seq.map((spell, index) => (
-                        <Grid item xs="auto" key={index} onDragOver={onDragOver} onDragEnd={dropMove} onDrop={dropInsertion} onDragEnter={(e) => { dragEnter(e, index) }} >
-                          <a data-wowhead={"spell=" + spellDB[spell][0].spellData.id} style={{ display: "flex" }} draggable onDragStart={(e) => { dragStart(e, index) }}>
+                        <Grid item xs="auto" key={index} onDragOver={onDragOver} onDragEnd={dropMove} onDrop={dropInsertion} onDragEnter={(e) => { dragEnter(e, index) }}>
+                          <a data-wowhead={"spell=" + spellDB[spell][0].spellData.id} style={{ display: "flex" }} draggable onDragStart={(e) => { dragStart(e, index) }} onContextMenu={(e) => removeSpellAtIndex(index, e) }>
                             <img
                               draggable="false"
                               height={40}

--- a/src/General/Modules/SequenceGenerator/SequenceGenerator.js
+++ b/src/General/Modules/SequenceGenerator/SequenceGenerator.js
@@ -89,8 +89,17 @@ export default function SequenceGenerator(props) {
     critMult: 1,
   };
 
+  const updateSequence = (sequence) => {
+    const simFunc = getSequence(selectedSpec);
+    const sim = simFunc(sequence, stats, {}, {});
+
+    // multiple state updates get bundled by react into one update
+    setSeq(sequence);
+    setResult(sim);
+  }
+
   const addSpell = (spell) => {
-    setSeq([...seq, spell]);
+    updateSequence([...seq, spell]);
   };
 
   const insertSpellAtIndex = (spell, index) => {
@@ -99,7 +108,7 @@ export default function SequenceGenerator(props) {
       spell,
       ...seq.slice(index)
     ];
-    setSeq(editSeq);
+    updateSequence(editSeq);
   };
 
   const moveSpell = (indexOld, indexNew) => {
@@ -107,11 +116,11 @@ export default function SequenceGenerator(props) {
     const dragItemContent = editSeq[indexOld];
     editSeq.splice(indexOld, 1);
     editSeq.splice(indexNew, 0, dragItemContent);
-    setSeq(editSeq);
+    updateSequence(editSeq);
   };
 
   const clearSeq = () => {
-    setSeq([]);
+    updateSequence([]);
   };
 
   const runSeq = () => {
@@ -122,7 +131,7 @@ export default function SequenceGenerator(props) {
   };
 
   const autoGen = () => {
-    setSeq(buildRamp("Primary", 10, [], stats.haste, "", discTalents));
+    updateSequence(buildRamp("Primary", 10, [], stats.haste, "", discTalents));
   };
 
   //#region Drag and Drop Functions

--- a/src/General/Modules/SequenceGenerator/SequenceGenerator.js
+++ b/src/General/Modules/SequenceGenerator/SequenceGenerator.js
@@ -14,6 +14,8 @@ import { SHAMANSPELLDB } from "Retail/Engine/EffectFormulas/Shaman/RestoShamanSp
 import { buildRamp } from "General/Modules/Player/DiscPriest/DiscRampGen";
 
 import LooksOneIcon from "@mui/icons-material/LooksOne";
+import { SpellIcon } from "./SpellIcon";
+import "./Sequence.css";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -236,22 +238,13 @@ export default function SequenceGenerator(props) {
 
                       {seq.map((spell, index) => (
                         <Grid item xs="auto" key={index} onDragOver={onDragOver} onDragEnd={dropMove} onDrop={dropInsertion} onDragEnter={(e) => { dragEnter(e, index) }}>
-                          <a data-wowhead={"spell=" + spellDB[spell][0].spellData.id} style={{ display: "flex" }} draggable onDragStart={(e) => { dragStart(e, index) }} onContextMenu={(e) => removeSpellAtIndex(index, e) }>
-                            <img
-                              draggable="false"
-                              height={40}
-                              width={40}
-                              src={require("Images/Spells/" + spellDB[spell][0].spellData.icon + ".jpg").default || ""}
-                              alt=""
-                              style={{
-                                borderRadius: 4,
-                                borderWidth: "1px",
-                                borderStyle: "solid",
-                                borderColor: "#008CFF",
-                                marginRight: 0,
-                              }}
-                            />
-                          </a>
+                          <SpellIcon
+                            spell={spellDB[spell][0]}
+                            draggable
+                            onDragStart={(e) => { dragStart(e, index) }}
+                            onContextMenu={(e) => removeSpellAtIndex(index, e)}
+                            style={{ display: "flex" }}
+                          />
                         </Grid>
                       ))}
                     </Grid>
@@ -273,23 +266,13 @@ export default function SequenceGenerator(props) {
                       <Grid container spacing={1}>
                         {spellList[cat].map((spell, i) => (
                           <Grid item xs="auto" key={spellDB[spell][0].spellData.id}>
-                            <a data-wowhead={"spell=" + spellDB[spell][0].spellData.id} style={{ display: "flex" }} draggable onDragStart={(e) => { dragStart(e, spell) }}>
-                              <img
-                                draggable="false" // lets drag the whole thing instead of just the image
-                                height={40}
-                                width={40}
-                                src={require("Images/Spells/" + spellDB[spell][0].spellData.icon + ".jpg").default || ""}
-                                alt=""
-                                onClick={(e) => addSpell(spell, e)}
-                                style={{
-                                  borderRadius: 4,
-                                  borderWidth: "1px",
-                                  borderStyle: "solid",
-                                  borderColor: "#ff8000",
-                                  marginRight: 0,
-                                }}
-                              />
-                            </a>
+                            <SpellIcon
+                              spell={spellDB[spell][0]}
+                              draggable
+                              onDragStart={(e) => { dragStart(e, spell) }}
+                              onClick={(e) => addSpell(spell, e)}
+                              style={{ display: "flex" }}
+                            />
                           </Grid>
                         ))}
                       </Grid>

--- a/src/General/Modules/SequenceGenerator/SpellIcon.js
+++ b/src/General/Modules/SequenceGenerator/SpellIcon.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export const SpellIcon = ({ spell, className, alt = '', ...others }) => {
+  if (!spell) {
+    return null;
+  }
+  const spellId = spell.spellData.id;
+  let icon = spell.spellData.icon;
+  if (!icon) {
+    return null;
+  }
+  icon = icon.replace('.jpg', '').replace(/-/g, '');
+  const baseURL = `//render-us.worldofwarcraft.com/icons/56`;
+
+  return (
+    <a
+      data-wowhead={"spell=" + spellId}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="spell_link"
+    >
+      <img
+        src={`${baseURL}/${icon}.jpg`}
+        alt={alt}
+        className={`icon ${className || ''}`}
+        {...others}
+      />
+    </a>
+  );
+};

--- a/src/General/Modules/SequenceGenerator/SpellIcon.js
+++ b/src/General/Modules/SequenceGenerator/SpellIcon.js
@@ -17,7 +17,6 @@ export const SpellIcon = ({ spell, className, alt = '', ...others }) => {
       data-wowhead={"spell=" + spellId}
       target="_blank"
       rel="noopener noreferrer"
-      className="spell_link"
     >
       <img
         src={`${baseURL}/${icon}.jpg`}

--- a/src/Retail/Engine/EffectFormulas/Evoker/PresEvokerRamps.js
+++ b/src/Retail/Engine/EffectFormulas/Evoker/PresEvokerRamps.js
@@ -21,7 +21,6 @@ const EVOKERCONSTANTS = {
     
     masteryMod: 1.8, 
     masteryEfficiency: 0.92, 
-    baseMastery: 0.14,
     baseMana: 10000,
 
     //CBT: {transferRate: 0.3, expectedOverhealing: 0.25},

--- a/src/Retail/Engine/EffectFormulas/Generic/RampBase.js
+++ b/src/Retail/Engine/EffectFormulas/Generic/RampBase.js
@@ -64,11 +64,12 @@ export const checkBuffActive = (buffs, buffName) => {
  */
 export const getStatMult = (currentStats, stats, statMods, specConstants) => {
     let mult = 1;
+    const baseMastery = specConstants.masteryMod / 100 * 8; // Every spec owns 8 mastery points baseline
 
     const critChance = 0.05 + currentStats['crit'] / GLOBALCONST.statPoints.crit / 100 + (statMods['crit'] || 0 );
     if (stats.includes("vers")) mult *= (1 + currentStats['versatility'] / GLOBALCONST.statPoints.vers / 100);
     if (stats.includes("crit")) mult *= (1 + critChance * currentStats['critMult']);
-    if (stats.includes("mastery")) mult *= (1+(specConstants.baseMastery + currentStats['mastery'] / GLOBALCONST.statPoints.mastery * specConstants.masteryMod / 100) * specConstants.masteryEfficiency) ;
+    if (stats.includes("mastery")) mult *= (1+(baseMastery + currentStats['mastery'] / GLOBALCONST.statPoints.mastery * specConstants.masteryMod / 100) * specConstants.masteryEfficiency);
     return mult;
 }
 

--- a/src/Retail/Engine/EffectFormulas/Paladin/HolyPaladinRamps.js
+++ b/src/Retail/Engine/EffectFormulas/Paladin/HolyPaladinRamps.js
@@ -394,7 +394,7 @@ export const runCastSequence = (sequence, stats, settings = {}, talents = {}) =>
             spell.coeff = spell.coeff * partialTickPercentage;
             
             if (buff.buffType === "damage") runDamage(state, spell, buff.name, atonementApp);
-            else if (buff.buffType === "healing") runHeal(state, spell, buff.name)
+            else if (buff.buffType === "heal") runHeal(state, spell, buff.name)
         })
 
         // Remove any buffs that have expired. Note that we call this after we handle partial ticks. 
@@ -459,7 +459,7 @@ export const runCastSequence = (sequence, stats, settings = {}, talents = {}) =>
                     else if (spell.buffType === "statsMult") {
                         state.activeBuffs.push({name: spellName, expiration: state.t + spell.buffDuration, buffType: "statsMult", value: spell.value, stat: spell.stat});
                     }
-                    else if (spell.buffType === "damage" || spell.buffType === "healing") {     
+                    else if (spell.buffType === "damage" || spell.buffType === "heal") {     
                         const newBuff = {name: spellName, buffType: spell.buffType, attSpell: spell,
                             tickRate: spell.tickRate, canPartialTick: spell.canPartialTick, next: state.t + (spell.tickRate / getHaste(state.currentStats))}
 

--- a/src/Retail/Engine/EffectFormulas/Shaman/RestoShamanRamps.js
+++ b/src/Retail/Engine/EffectFormulas/Shaman/RestoShamanRamps.js
@@ -74,6 +74,7 @@ const getSqrt = (targets) => {
   return Math.sqrt(targets);
 }
 
+const getHotName = (spellName) => spellName; // + " (hot)" throws issues when doing things by name comparison
 export const runHeal = (state, spell, spellName, compile = true) => {
 
   // Pre-heal processing
@@ -208,8 +209,10 @@ export const runCastSequence = (sequence, stats, settings = {}, talents = {}) =>
       const spell = buff.attSpell;
       spell.coeff = spell.coeff * partialTickPercentage;
 
-      if (buff.buffType === "damage") runDamage(state, spell, buff.name);
-      else if (buff.buffType === "healing") runHeal(state, spell, buff.name + "(hot)")
+      if (buff.buffType === "damage")
+        runDamage(state, spell, buff.name);
+      else if (buff.buffType === "heal")
+        runHeal(state, spell, getHotName(buff.name));
     })
 
     // Remove any buffs that have expired. Note that we call this after we handle partial ticks. 


### PR DESCRIPTION
- Added a Spell Icon component which removes the need to upload icons by grabbing them from blizzard (at least for use in the sequencer, can move it up for use in other modules too)
- Right click to remove entries in the Sequence
- Fixed a bug where partial ticks weren't being calculated due to a spelling error
- Improved baseline mastery calculations as its the same for all specs
- Sequence automatically calculates the new results on any change now. This needs to be reviewed in the future when complexity or iterations get added, but for the current state it improves the usability a lot.