### PR TITLE
Fix for Broken Images on Welcome Dialog

### DIFF
--- a/src/General/Modules/SetupAndMenus/GameTypeToggle.js
+++ b/src/General/Modules/SetupAndMenus/GameTypeToggle.js
@@ -9,6 +9,9 @@ import { Tooltip, Typography } from "@mui/material";
 import makeStyles from '@mui/styles/makeStyles';
 import { toggleContent } from "Redux/Actions";
 
+import RetailLogo from "../../../Images/Logos/Logo_Dragonflight.png";
+import ClassicLogo from "../../../Images/Logos/Logo_LichKingComingSoon.png";
+
 const useStyles = makeStyles((theme) => ({
   root: {
     [theme.breakpoints.down('md')]: {
@@ -78,12 +81,12 @@ export default function GameTypeSwitch(props) {
   return (
     <ToggleButtonGroup value={gameType} exclusive onChange={handleContent} aria-label="gameToggle" size="large">
       {/* ---------------------------------------------------------------------------------------------- */
-      /*                                  Shadowlands Game Type Toggle                                  */
+      /*                                  Dragonflight Game Type Toggle                                  */
       /* ----------------------------------------------------------------------------------------------  */}
       <ToggleButton className={classes.root} value="Retail" aria-label="retailLabel">
         <Tooltip title={t("GameTypeToggle.Retail")} arrow>
           <div style={{ display: "inline-flex" }}>
-            <img src={require("../../../Images/Logos/Logo_Dragonflight.png").default} alt={t("Dragonflight")} />
+            <img src={RetailLogo} alt={t("Dragonflight")} />
           </div>
         </Tooltip>
       </ToggleButton>
@@ -94,7 +97,7 @@ export default function GameTypeSwitch(props) {
       <ToggleButton className={classes.root} value="Classic" aria-label="classicLabel" disabled>
         <Tooltip title={t("GameTypeToggle.Classic")} arrow>
           <div style={{ display: "inline-flex" }}>
-            <img src={require("../../../Images/Logos/Logo_LichKingComingSoon.png").default} alt={t("Burning Crusade")} />
+            <img src={ClassicLogo} alt={t("Wrath of the Lich King")} />
           </div>
         </Tooltip>
       </ToggleButton>

--- a/src/locale/ch/translate.json
+++ b/src/locale/ch/translate.json
@@ -119,7 +119,7 @@
     "External": "External",
     "Filter": "Filter",
     "GameTypeToggle": {
-      "Classic": "Change to Classic (Burning Crusade)",
+      "Classic": "Change to Classic (Wrath of the Lich King)",
       "Retail": "Change to Retail (Shadowlands)"
     },
     "HPS": "HPS",
@@ -360,6 +360,7 @@
       "GameTypeMessage": "Select which version you'd like to start with.",
       "WelcomeTo": "Welcome To"
     },
+    "WrathOfTheLichKing": "Wrath of the Lich King",
     "Yes": "Yes",
     "itemTags": {
       "effect": "Effect",

--- a/src/locale/de/translate.json
+++ b/src/locale/de/translate.json
@@ -119,7 +119,7 @@
     "External": "External",
     "Filter": "Filter",
     "GameTypeToggle": {
-      "Classic": "Change to Classic (Burning Crusade)",
+      "Classic": "Change to Classic (Wrath of the Lich King)",
       "Retail": "Change to Retail (Shadowlands)"
     },
     "HPS": "HPS",
@@ -360,6 +360,7 @@
       "GameTypeMessage": "Select which version you'd like to start with.",
       "WelcomeTo": "Welcome To"
     },
+    "WrathOfTheLichKing": "Wrath of the Lich King",
     "Yes": "Yes",
     "itemTags": {
       "effect": "Bewirken",

--- a/src/locale/en/translate.json
+++ b/src/locale/en/translate.json
@@ -471,6 +471,7 @@
       "GameTypeMessage": "Select which version you'd like to start with.",
       "WelcomeTo": "Welcome To"
     },
+    "WrathOfTheLichKing": "Wrath of the Lich King",
     "Yes": "Yes",
     "itemTags": {
       "effect": "Effect",

--- a/src/locale/fr/translate.json
+++ b/src/locale/fr/translate.json
@@ -119,7 +119,7 @@
     "External": "External",
     "Filter": "Filtrer",
     "GameTypeToggle": {
-      "Classic": "Change to Classic (Burning Crusade)",
+      "Classic": "Change to Classic (Wrath of the Lich King)",
       "Retail": "Change to Retail (Shadowlands)"
     },
     "HPS": "HPS",
@@ -360,6 +360,7 @@
       "GameTypeMessage": "Select which version you'd like to start with.",
       "WelcomeTo": "Welcome To"
     },
+    "WrathOfTheLichKing": "Wrath of the Lich King",
     "Yes": "Oui",
     "itemTags": {
       "effect": "Effet",

--- a/src/locale/ru/translate.json
+++ b/src/locale/ru/translate.json
@@ -119,7 +119,7 @@
     "External": "External",
     "Filter": "Filter",
     "GameTypeToggle": {
-      "Classic": "Change to Classic (Burning Crusade)",
+      "Classic": "Change to Classic (Wrath of the Lich King)",
       "Retail": "Change to Retail (Shadowlands)"
     },
     "HPS": "HPS",
@@ -360,6 +360,7 @@
       "GameTypeMessage": "Select which version you'd like to start with.",
       "WelcomeTo": "Welcome To"
     },
+    "WrathOfTheLichKing": "Wrath of the Lich King",
     "Yes": "Yes",
     "itemTags": {
       "effect": "Эффект",


### PR DESCRIPTION
Remake of PR #1056

I noticed that the logos for Dragonflight and WotLK (Coming Soon) were appearing as broken images on the live site, so I wanted to fix those.