### PR TITLE
Blessing of Summer nerf

### DIFF
--- a/src/Retail/Engine/EffectFormulas/Paladin/HolyPaladinRamps2.js
+++ b/src/Retail/Engine/EffectFormulas/Paladin/HolyPaladinRamps2.js
@@ -279,7 +279,7 @@ const getDamMult = (state, buffs, activeAtones, t, spellName, talents) => {
     }
 
     if (checkBuffActive(state.activeBuffs, "Blessing of Summer")) {
-        mult *= 1 + (0.4 * 0.3);
+        mult *= 1 + (0.4 * 0.2);
     }
 
     return mult;

--- a/src/Retail/Engine/EffectFormulas/Paladin/HolyPaladinSpellDB.js
+++ b/src/Retail/Engine/EffectFormulas/Paladin/HolyPaladinSpellDB.js
@@ -404,7 +404,7 @@ export const PALADINSPELLDB = {
                     name: "Blessing of Summer",
                     type: "buff",
                     buffType: "special",
-                    value: 0.4 * 0.3, // Unused, implemented in getDamMulti
+                    value: 0.4 * 0.2, // Unused, implemented in getDamMulti
                     buffDuration: 30, 
                 };
 


### PR DESCRIPTION
Summer was recently nerfed (twice technically) to now only 20% additional damage 40% of the time instead of 30% (changed in SpellDB for completion sake) 