### PR TITLE
Fix Call to Dominance duration based on ptr hotfixes

### DIFF
--- a/src/Retail/Engine/EffectFormulas/Generic/TrinketData.js
+++ b/src/Retail/Engine/EffectFormulas/Generic/TrinketData.js
@@ -169,7 +169,7 @@ export const raidTrinketData = [
         coefficient: 0.442388,
         table: -1,
         stat: "intellect",
-        duration: 10,
+        duration: 20,
         ppm: 3,
       },
     ],


### PR DESCRIPTION
Call to Dominance trinket data still has 10s duration but was increased to 20s in the 10.2 PTR