### PR TITLE
Classic: Fixed an edge case where simulation could break if a set had…

### DIFF
--- a/src/General/Modules/TopGear/Engine/TopGearEngineClassic.js
+++ b/src/General/Modules/TopGear/Engine/TopGearEngineClassic.js
@@ -321,13 +321,16 @@ function compileSetStats(itemSet) {
     spirit: 173, // Technically changes per race.
     mp5: 0,
     hps: 0,
+    crit: 0,
+    mastery: 0,
+    haste: 0,
   }
 
     for (let i = 0; i < itemSet.itemList.length; i++) {
       let item = itemSet.itemList[i];
 
       for (const [stat, value] of Object.entries(item.stats)) {
-        
+
         //if (stat in setStats) {
           //setStats[stat as keyof Stats] += value || 0;
           setStats[stat] = (setStats[stat] || 0) + value;


### PR DESCRIPTION
… 0 of a stat.