### PR TITLE
[Mw] Fix mistweaver mastery coefficient

### DIFF
--- a/src/General/Engine/STAT.ts
+++ b/src/General/Engine/STAT.ts
@@ -26,7 +26,7 @@ export const BASESTAT = {
   MASTERY: { // This is not really used anymore.
     "Preservation Evoker": 0,
     "Restoration Druid": 0.04,
-    "Mistweaver Monk": 0.336,
+    "Mistweaver Monk": 0.5544,
     "Holy Paladin": 0.12,
     "Holy Priest": 0.1,
     "Discipline Priest": 0.108,
@@ -56,7 +56,7 @@ export const STATCONVERSION = {
     MASTERYMULT: {
       "Preservation Evoker": 1.8,
       "Restoration Druid": 0.728,
-      "Mistweaver Monk": 4.2,
+      "Mistweaver Monk": 6.93,
       "Holy Paladin": 1.5,
       "Holy Priest": 0.95625,
       "Discipline Priest": 1.35,
@@ -79,7 +79,7 @@ export const STATPERONEPERCENT = {
     MASTERYMULT: {
       "Preservation Evoker": 1.8,
       "Restoration Druid": 0.5,
-      "Mistweaver Monk": 4.2,
+      "Mistweaver Monk": 6.93,
       "Holy Paladin": 1.5,
       "Holy Priest": 1.125,
       "Discipline Priest": 1.35,


### PR DESCRIPTION
Mistweaver's mastery coefficient was changed several times in TWW beta and landed at 6.93 prior to 11.1 launch. Updating.
Images are from Top Gear on gear sets with 0 mastery and no mastery procs
Before 
![image](https://github.com/user-attachments/assets/4ab3e65a-de3d-4898-bcac-690823b31a52)

After
![image](https://github.com/user-attachments/assets/e8cabd43-9cf5-41b1-a521-52763c32ec32)
