### PR TITLE
Add a toggle for embellish value usage

### DIFF
--- a/src/Redux/Reducers/RootReducer.ts
+++ b/src/Redux/Reducers/RootReducer.ts
@@ -46,6 +46,7 @@ const initialState : RootState = {
     upgradeFinderMetric: { value: "Show % Upgrade", options: ["Show % Upgrade", "Show HPS"], category: "upgradeFinder", type: "selector", gameType: "Retail" },
 
     topGearAutoGem: { value: false, options: [true, false], category: "topGear", type: "selector", gameType: "Retail" },
+    calculateEmbellishments: { value: true, options: [true, false], category: "embellishments", type: "selector", gameType: "Retail" },
     socketedGems: { value: 4, options: [0, 1, 2, 3, 4, 5, 6, 7, 8], category: "embellishments", type: "Entry", gameType: "Retail" },
     
     gemSettings: {value: "Simple", options: ["Simple", /*"Precise (Beta)"*/], category: "topGear", type: "selector", gameType: "Retail"}, // TODO: Add a "Keep current".

--- a/src/Retail/Engine/EffectFormulas/Generic/EmbellishmentData.js
+++ b/src/Retail/Engine/EffectFormulas/Generic/EmbellishmentData.js
@@ -4,6 +4,10 @@ import { convertPPMToUptime, processedValue, runGenericPPMTrinket, runGenericPPM
 
 
 export const getEmbellishmentEffect = (effectName, itemLevel, additionalData) => {
+  if (getSetting(additionalData.settings, "calculateEmbellishments") === false) { // I hate that JS false and 0 are ==. Might break if getSetting gets changed ?
+    return {};
+  }
+
     let activeEffect;
     
     

--- a/src/locale/en/translate.json
+++ b/src/locale/en/translate.json
@@ -407,6 +407,10 @@
           "title": "Pheromone Secreter",
           "tooltip": "Pick which secondaries you intend to socket in your Pheromone Secreter trinket."
         },
+        "calculateEmbellishments": {
+          "title": "Use Embellishments",
+          "tooltip": "Take into account embellishments' impact in sims. Useful for 3-crafted-items situation where you can move one of the embellishments."
+        },
         "socketedGems": {
           "title": "Socketed Gems",
           "tooltip": "Number of gems you have socketed. Ignored by Top Gear which will just use your actual set."


### PR DESCRIPTION
Adds a toggle in the options ( both topgear and upgrade finder ) that controls calculation of values from embellishes. Default state is toggled on, so it does process their value. Toggle off results in ignore of embellishes.

[FIle with simc ready for testing](https://github.com/user-attachments/files/19514538/testSimc.txt)

Top Gear with toggle on/off:
![image](https://github.com/user-attachments/assets/571c3482-a3d4-4a25-b84a-650b16229ae8)
![image](https://github.com/user-attachments/assets/db73e283-3c52-4fdb-9e8a-2bd48173c640)

**NOTE**: Remove stix wep from import (Металлодетектор Стикса (678))

Upgrade finder with toggle ON:
![image](https://github.com/user-attachments/assets/97ea784e-0ff1-42a2-81e3-23179d66b1d7)
~~
With OFF
![image](https://github.com/user-attachments/assets/075f346b-89d8-4d5c-9606-8d6fafcf6be4)

