### PR TITLE
BUGFIX - upgrade PanelCrafted.js to use getNumUpgrades instead of length

### DIFF
--- a/src/General/Modules/UpgradeFinder/Panels/PanelCrafted.js
+++ b/src/General/Modules/UpgradeFinder/Panels/PanelCrafted.js
@@ -100,7 +100,7 @@ export default function CraftedGearContainer(props) {
                               <Divider flexItem orientation="vertical" style={{ margin: "0px 5px 0px 0px" }} />
                               {craftedDB[key]} -{" "}
                               {
-                                [...filterItemListBySource(itemDifferentials, "-4", key, itemLevels.crafted[difficulty])].length
+                                getNumUpgrades(itemDifferentials, -4, parseInt(key))
                               }{" "}
                               Upgrades
                             </Typography>


### PR DESCRIPTION
Currently there is a bug where the number that is shown as an upgrade will instead show the total number of items in a category:
![image](https://github.com/user-attachments/assets/37f7df34-7e00-49ae-9746-227c33ee458d)


This PR updates the logic for PanelCrafted.js to better align with how other panels calculate their total number of upgrades per category.
![image](https://github.com/user-attachments/assets/879868dd-f842-4172-a823-e38184da8b31)
