### PR TITLE
[feature] Add Wowhead Trinket Tier List + Cheat Sheet Export

### DIFF
--- a/src/General/Modules/TopGear/Report/MenuDropdown.tsx
+++ b/src/General/Modules/TopGear/Report/MenuDropdown.tsx
@@ -3,10 +3,11 @@ import { Button, Menu, MenuItem } from "@mui/material";
 
 interface HoverMenuProps {
   handleClicked: (value: string) => void;
-  gameType: gameTypes;
+  exportOptions: string[];
+  sx?: any;
 }
 
-export default function HoverMenu({ handleClicked, gameType }: HoverMenuProps) {
+export default function HoverMenu({ handleClicked, exportOptions, sx }: HoverMenuProps) {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
@@ -19,18 +20,6 @@ export default function HoverMenu({ handleClicked, gameType }: HoverMenuProps) {
     setAnchorEl(null);
   };
 
-  const exportOptions = []
-
-  if (gameType === "Classic") {
-    exportOptions.push("ReforgeLite Export");
-    exportOptions.push("Wowhead Gear Planner");
-  }
-  if (window.location.href.includes("localhost") || window.location.href.includes("ptr")) {
-    exportOptions.push("Wowhead BIS List");
-    exportOptions.push("Icy Veins BIS List")
-
-  }
-
   return (
     <>
       <Button
@@ -40,6 +29,7 @@ export default function HoverMenu({ handleClicked, gameType }: HoverMenuProps) {
         onClick={handleClick}
         variant="outlined"
         color="primary"
+        sx={sx}
         //size="small"
       >
         Export

--- a/src/General/Modules/TopGear/Report/TopGearExports.ts
+++ b/src/General/Modules/TopGear/Report/TopGearExports.ts
@@ -5,10 +5,11 @@
 
 import { getInstanceName, getSourceName } from "Databases/InstanceDB";
 import { CONSTANTS } from "General/Engine/CONSTANTS";
-import { getTranslatedItemName } from "General/Engine/ItemUtilities";
+import { getTranslatedItemName, getItemProp } from "General/Engine/ItemUtilities";
 import Item from "General/Items/Item";
 import Player from "General/Modules/Player/Player";
 import { getTranslatedSlotName } from "locale/slotsLocale";
+import { TRINKET_SOURCES } from "General/Modules/TrinketAnalysis/TrinketAnalysis";
 
 // {"player":{"name":"Player","equipment":{"items":[{"id":78785,"enchant":4207,"gems":[52296,52207]},{"id":78382,"reforging":119},{"id":78835,"enchant":4199,"gems":[52207,52207],"reforging":117},{"id":77096,"enchant":4096,"gems":[52207],"reforging":119},{"id":78755,"enchant":4063,"gems":[52207,52207,52208],"reforging":119},{"id":71262,"gems":[0],"reforging":117},{"id":76157,"gems":[52207,0],"reforging":119},{"id":75117,"gems":[0],"reforging":167},{"id":78805,"enchant":4112,"gems":[52207,52207,52207],"reforging":117},{"id":77172,"enchant":4069,"gems":[52207,52208],"reforging":119},{"id":77109,"gems":[52207],"reforging":117},{"id":71211,"reforging":145},{"id":77976},{"id":72898},{"id":78485,"enchant":4084},{"id":72878,"reforging":167},{"id":77083,"gems":[52207],"reforging":117}]}}}
 export const exportReforgeLite = (player: Player, itemSet: Item[], reforges: any) => {
@@ -312,3 +313,108 @@ export function exportWowheadGearList(itemSet, spec, gameType = "Retail") {
 
   return formattedArray;
 }
+
+// wowhead trinket tier list export generator
+export function exportWowheadTierList(trinketData: any[]) {
+  const getQualityAndSource = (trinket: any) => {
+    const sources = getItemProp(trinket.id, "sources", "Retail");
+    if (!sources || sources.length === 0) return { quality: 1, source: "delves" };
+    
+    const instanceId = sources[0].instanceId;
+    
+    if (TRINKET_SOURCES.delves.includes(instanceId)) return { quality: 2, source: "delves" };
+    if (TRINKET_SOURCES.dungeon.includes(instanceId)) return { quality: 3, source: "dungeon" };
+    if (TRINKET_SOURCES.raid.includes(instanceId)) return { quality: 4, source: "raid" };
+    if (TRINKET_SOURCES.crafted.includes(instanceId)) return { quality: 5, source: "crafting" };
+    
+    // just fallback to white quality (pvp, other sources, etc)
+    return { quality: 1, source: "delves" };
+  };
+
+  const formatTooltipName = (name: string) => {
+    const sanitized = name
+      .toLowerCase()
+      .replace(/['\s]/g, "_")
+      .replace(/,/g, "");
+    return `${sanitized}_tooltip`;
+  };
+
+  const trinketScores = trinketData.map((trinket: any) => ({
+    ...trinket,
+    score: trinket.highestLevel ? trinket["i" + trinket.highestLevel] : 0
+  })).filter((t: any) => t.score > 0);
+  trinketScores.sort((a: any, b: any) => b.score - a.score);
+  
+  const tooltipThreshold = 0.80
+  const tierConfigs = [
+    { name: "S", bg: "q5", threshold: 0.95 },
+    { name: "A", bg: "q4", threshold: tooltipThreshold },
+    { name: "B", bg: "q3", threshold: 0.75 },
+    { name: "C", bg: "q2", threshold: 0.60 },
+    { name: "D", bg: "q1", threshold: 0.50 },
+    { name: "F", bg: "q10", threshold: 0 }
+  ];
+
+  const tiers: { [key: string]: any[] } = tierConfigs.reduce((acc, tier) => {
+    acc[tier.name] = [];
+    return acc;
+  }, {} as { [key: string]: any[] });
+
+  const maxScore = trinketScores[0]?.score || 1;
+  trinketScores.forEach((trinket: any) => {
+    const score = trinket.score;
+    const tier = tierConfigs.find(t => score >= maxScore * t.threshold);
+    if (tier) tiers[tier.name].push(trinket);
+  });
+
+  const tierList = ["[tier-list=rows grid]"];
+  const tooltips: string[] = [];
+
+  tierConfigs.forEach(tierConfig => {
+    const tierTrinkets = tiers[tierConfig.name];
+    if (tierTrinkets.length === 0) return;
+
+    tierList.push("[tier]");
+    tierList.push(`[tier-label bg=${tierConfig.bg}]${tierConfig.name}[/tier-label]`);
+    tierList.push("[tier-content]");
+
+    tierTrinkets.forEach((trinket: any) => {
+      const { quality, source } = getQualityAndSource(trinket);
+      const tooltipName = formatTooltipName(trinket.name);
+      
+      const includeTooltip = tierConfig.threshold >= tooltipThreshold || trinket.warningFlag;
+      const tooltipAttr = includeTooltip ? ` tooltip="${tooltipName}"` : "";
+      
+      tierList.push(`[icon-badge=${trinket.id} quality=${quality} display-options=${source}${tooltipAttr}]`);
+      
+      if (includeTooltip) {
+        tooltips.push(`[tooltip name=${tooltipName}][/tooltip]`);
+      }
+    });
+
+    tierList.push("[/tier-content]");
+    tierList.push("[/tier]");
+  });
+
+  tierList.push("[/tier-list]");
+
+  const displayOptions = [
+    "[grid width=95% align=centered]",
+    "[display-option=raid icon=inv_achievement_raidnerubian_queenansurek checked color=4]Raid[/display-option]",
+    "[display-option=dungeon icon=inv_relics_hourglass checked color=3]Mythic Plus[/display-option]",
+    "[display-option=delves icon=ui_delves checked color=2]Delves[/display-option]",
+    "[display-option=crafting icon=inv_10_blacksmithing_consumable_repairhammer_color2 checked color=5]Crafting[/display-option]",
+    "[/grid]",
+  ];
+
+  const results = [
+    "{{REMOVE ME AFTER ADJUSTING TOOLTIPS}}", // user should not blindly paste without tooltips!!!
+    ...displayOptions,
+    ...tierList, 
+    "", // extra space for more visual clarity to manually edit
+    ...tooltips
+  ]
+
+  return results.join('\n');
+}
+

--- a/src/General/Modules/TopGear/Report/TopGearExports.ts
+++ b/src/General/Modules/TopGear/Report/TopGearExports.ts
@@ -314,6 +314,47 @@ export function exportWowheadGearList(itemSet, spec, gameType = "Retail") {
   return formattedArray;
 }
 
+// wowhead trinket cheat sheet export generator
+export function exportWowheadTrinketCheatSheet(trinketData: any[]) {
+  const getBonusTag = (itemId: number) => {
+    const sources = getItemProp(itemId, "sources", "Retail");
+    if (!sources || sources.length === 0) return "[=gv-delves]";
+    
+    const source = sources[0];
+    
+    if (CONSTANTS.currentRaidIDs.includes(source.instanceId)) return "[=gv-raid]";
+    if (source.instanceId === -69) return "[=gv-delves]";
+    if (source.instanceId === -1) {
+      const instanceID = source.encounterId;
+      if ([1210, 1272, 1268, 1267, 1298, 1271, 1270, 1303].includes(instanceID)) return "[=gv-tww-dun]";
+      if ([1012, 1178].includes(instanceID)) return "[=gv-bfa-dun]";
+      if ([1194, 11941, 1185].includes(instanceID)) return "[=gv-sl-dun]";
+      return "[=gv-mid-dun]";
+    }
+    
+    return "[=gv-delves]";
+  };
+
+  const trinketScores = trinketData.map((trinket: any) => ({
+    ...trinket,
+    score: trinket.highestLevel ? trinket["i" + trinket.highestLevel] : 0
+  })).filter((t: any) => t.score > 0);
+  
+  trinketScores.sort((a: any, b: any) => b.score - a.score);
+
+  const top4 = trinketScores.slice(0, 4);
+  
+  const formatTrinket = (trinket: any) => {
+    const bonusTag = getBonusTag(trinket.id);
+    return `${trinket.id};${bonusTag}`;
+  };
+
+  const bis = top4.slice(0, 2).map(formatTrinket).join(",");
+  const alt = top4.slice(2, 4).map(formatTrinket).join(",");
+
+  return `[build-items cols=2 url=guide=3292 bis=${bis} alt=${alt}]Trinkets[/build-items]`;
+}
+
 // wowhead trinket tier list export generator
 export function exportWowheadTierList(trinketData: any[]) {
   const getQualityAndSource = (trinket: any) => {

--- a/src/General/Modules/TopGear/Report/TopGearExports.ts
+++ b/src/General/Modules/TopGear/Report/TopGearExports.ts
@@ -218,6 +218,37 @@ const wowheadClassColors = {
   "Mistweaver Monk": "c10"
 }
 
+// helper for trinket scoring
+function getTrinketScores(trinketData: any[]) {
+  return trinketData
+    .map((trinket: any) => ({
+      ...trinket,
+      score: trinket.highestLevel ? trinket["i" + trinket.highestLevel] : 0
+    }))
+    .filter((t: any) => t.score > 0)
+    .sort((a: any, b: any) => b.score - a.score);
+}
+
+// wowhead's great vault bonus tag info from item
+function getWowheadBonusTag(itemId: number) {
+  const sources = getItemProp(itemId, "sources", "Retail");
+  if (!sources || sources.length === 0) return "[=gv-delves]";
+  
+  const source = sources[0];
+  
+  if (CONSTANTS.currentRaidIDs.includes(source.instanceId)) return "[=gv-raid]";
+  if (source.instanceId === -69) return "[=gv-delves]";
+  if (source.instanceId === -1) {
+    const instanceID = source.encounterId;
+    if ([1210, 1272, 1268, 1267, 1298, 1271, 1270, 1303].includes(instanceID)) return "[=gv-tww-dun]";
+    if ([1012, 1178].includes(instanceID)) return "[=gv-bfa-dun]";
+    if ([1194, 11941, 1185].includes(instanceID)) return "[=gv-sl-dun]";
+    return "[=gv-mid-dun]";
+  }
+  
+  return "[=gv-delves]";
+}
+
 export function exportIcyVeinsGearList(itemSet, spec, gameType = "Retail") {
   const results = ["<table>",
                     "<tr>",
@@ -291,14 +322,7 @@ export function exportWowheadGearList(itemSet, spec, gameType = "Retail") {
       else source = wowheadCodes[item.source.encounterId] || "";
 
       if (gameType === "Retail") {
-        if (CONSTANTS.currentRaidIDs.includes(item.source.instanceId)) bonusTag = " bonus=[=gv-raid]";
-        else if (item.source.instanceId === -1) {
-          const instanceID = item.source.encounterId;
-          if ([1210, 1272, 1268, 1267, 1298, 1271, 1270, 1303].includes(instanceID)) bonusTag = " bonus=[=gv-tww-dun]"; // TWW
-          else if ([1012, 1178].includes(instanceID)) bonusTag = " bonus=[=gv-bfa-dun]"; // BFA
-          else if ([1194, 11941, 1185].includes(instanceID)) bonusTag = " bonus=[=gv-sl-dun]"; // Shadowlands
-        }
-        else if (item.source.instanceId === -69) bonusTag = " bonus=[=gv-delves]"
+        bonusTag = ` bonus=${getWowheadBonusTag(item.id)}`;
       }
 
     }
@@ -316,36 +340,12 @@ export function exportWowheadGearList(itemSet, spec, gameType = "Retail") {
 
 // wowhead trinket cheat sheet export generator
 export function exportWowheadTrinketCheatSheet(trinketData: any[]) {
-  const getBonusTag = (itemId: number) => {
-    const sources = getItemProp(itemId, "sources", "Retail");
-    if (!sources || sources.length === 0) return "[=gv-delves]";
-    
-    const source = sources[0];
-    
-    if (CONSTANTS.currentRaidIDs.includes(source.instanceId)) return "[=gv-raid]";
-    if (source.instanceId === -69) return "[=gv-delves]";
-    if (source.instanceId === -1) {
-      const instanceID = source.encounterId;
-      if ([1210, 1272, 1268, 1267, 1298, 1271, 1270, 1303].includes(instanceID)) return "[=gv-tww-dun]";
-      if ([1012, 1178].includes(instanceID)) return "[=gv-bfa-dun]";
-      if ([1194, 11941, 1185].includes(instanceID)) return "[=gv-sl-dun]";
-      return "[=gv-mid-dun]";
-    }
-    
-    return "[=gv-delves]";
-  };
-
-  const trinketScores = trinketData.map((trinket: any) => ({
-    ...trinket,
-    score: trinket.highestLevel ? trinket["i" + trinket.highestLevel] : 0
-  })).filter((t: any) => t.score > 0);
-  
-  trinketScores.sort((a: any, b: any) => b.score - a.score);
+  const trinketScores = getTrinketScores(trinketData);
 
   const top4 = trinketScores.slice(0, 4);
   
   const formatTrinket = (trinket: any) => {
-    const bonusTag = getBonusTag(trinket.id);
+    const bonusTag = getWowheadBonusTag(trinket.id);
     return `${trinket.id};${bonusTag}`;
   };
 
@@ -380,11 +380,7 @@ export function exportWowheadTierList(trinketData: any[]) {
     return `${sanitized}_tooltip`;
   };
 
-  const trinketScores = trinketData.map((trinket: any) => ({
-    ...trinket,
-    score: trinket.highestLevel ? trinket["i" + trinket.highestLevel] : 0
-  })).filter((t: any) => t.score > 0);
-  trinketScores.sort((a: any, b: any) => b.score - a.score);
+  const trinketScores = getTrinketScores(trinketData);
   
   const tooltipThreshold = 0.80
   const tierConfigs = [

--- a/src/General/Modules/TopGear/Report/TopGearReport.js
+++ b/src/General/Modules/TopGear/Report/TopGearReport.js
@@ -282,6 +282,17 @@ function displayReport(
 
   console.log(fullItemList);
 
+  // setup export button menu options
+  let exportOptions = [];
+  if (gameType === "Classic") {
+    exportOptions.push("ReforgeLite Export");
+    exportOptions.push("Wowhead Gear Planner");
+  }
+  if (window.location.href.includes("localhost") || window.location.href.includes("ptr")) {
+    exportOptions.push("Wowhead BIS List");
+    exportOptions.push("Icy Veins BIS List");
+  }
+
   const handleExportMenuClick = (buttonClicked) => {
     //alert("Exporting to " + buttonClicked, result.id);
     if (buttonClicked === "ReforgeLite Export") {
@@ -449,7 +460,7 @@ function displayReport(
                       <Grid item>
                         <MenuDropdown
                           handleClicked={handleExportMenuClick}
-                          gameType={gameType}
+                          exportOptions={exportOptions}
                         />
                       </Grid>
                     </Grid>

--- a/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
+++ b/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
@@ -28,6 +28,7 @@ import { getAllTrinketData } from "Retail/Engine/EffectFormulas/Generic/Trinkets
 import GenericDialog from "General/Modules/TopGear/Report/GenericDialog";
 import MenuDropdown from "General/Modules/TopGear/Report/MenuDropdown";
 import { exportWowheadTierList, exportWowheadTrinketCheatSheet } from "General/Modules/TopGear/Report/TopGearExports";
+import { CONSTANTS } from "General/Engine/CONSTANTS";
 
 
 function TabPanel(props) {
@@ -192,11 +193,7 @@ const handleDownload = () => {
 };
 
 export const TRINKET_SOURCES = {
-  raid: [
-    1314, // Dreamrift
-    1308, // March
-    1307, // Voidspire
-  ],
+  raid: CONSTANTS.currentRaidIDs,
   dungeon: [-1],
   delves: [-69],
   crafted: [-4],

--- a/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
+++ b/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
@@ -27,7 +27,7 @@ import { downloadJson } from "./TrinketJSONDownload"
 import { getAllTrinketData } from "Retail/Engine/EffectFormulas/Generic/Trinkets/TrinketEffectFormulas.js"
 import GenericDialog from "General/Modules/TopGear/Report/GenericDialog";
 import MenuDropdown from "General/Modules/TopGear/Report/MenuDropdown";
-import { exportWowheadTierList } from "General/Modules/TopGear/Report/TopGearExports";
+import { exportWowheadTierList, exportWowheadTrinketCheatSheet } from "General/Modules/TopGear/Report/TopGearExports";
 
 
 function TabPanel(props) {
@@ -437,12 +437,16 @@ export default function TrinketAnalysis(props) {
   let exportOptions = ["Download JSON"];
   if (window.location.href.includes("localhost") || window.location.href.includes("ptr")) {
     exportOptions.push("Wowhead Tier List");
+    exportOptions.push("Wowhead Cheat Sheet");
   }
 
   const handleExportMenuClick = (buttonClicked) => {
     if (buttonClicked === "Wowhead Tier List") {
       setDialogOpen(true);
       setDialogText(exportWowheadTierList(activeTrinkets));
+    } else if (buttonClicked === "Wowhead Cheat Sheet") {
+      setDialogOpen(true);
+      setDialogText(exportWowheadTrinketCheatSheet(activeTrinkets));
     } else if (buttonClicked === "Download JSON") {
       handleDownload();
     }

--- a/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
+++ b/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
@@ -191,6 +191,25 @@ const handleDownload = () => {
   downloadJson(jsonString, 'QE-trinket-data.json');
 };
 
+export const TRINKET_SOURCES = {
+  raid: [
+    1314, // Dreamrift
+    1308, // March
+    1307, // Voidspire
+  ],
+  dungeon: [-1],
+  delves: [-69],
+  crafted: [-4],
+  timewalking: [-12],
+  other: [
+    1192, // World Bosses
+    1205, // DF World Bosses
+    -18, // PVP
+    -17, // PVP
+    -85, // Also PVP
+  ],
+};
+
 export default function TrinketAnalysis(props) {
   useEffect(() => {
     trackPageView(window.location.pathname + window.location.search);
@@ -222,26 +241,6 @@ export default function TrinketAnalysis(props) {
   /* ---------------------------------------------------------------------------------------------- */
   const sourceHandler = (array, sources, playerSpec) => {
     let results = [];
-    const raidSources = [
-      1314, // Dreamrift
-      1308, // March
-      1307, // Voidspire
-    ];
-    const dungeonSources = [
-      -1, // General Dungeons
-    ];
-    const delveSources = [
-      -69
-    ]
-    const otherSources = [
-      1192, // World Bosses
-      1205, // DF World Bosses
-      -18, // PVP
-      -17, // PVP
-      -85, // Also PVP
-      -4,
-    ];
-    const timewalkingSources = [-12]
 
     /* ---------------------------------------------------------------------------------------------- */
     /*                                   The Rest & Raids & Dungeons                                  */
@@ -253,11 +252,11 @@ export default function TrinketAnalysis(props) {
         return (
           (item["sources"] === undefined && sources.includes("The Rest")) ||
           (item["sources"] &&
-            ((otherSources.includes(item["sources"][0]["instanceId"]) && sources.includes("The Rest")) ||
-              (raidSources.includes(item["sources"][0]["instanceId"]) && sources.includes("Raids")) ||
-              (delveSources.includes(item["sources"][0]["instanceId"]) && sources.includes("Delves")) ||
-              (timewalkingSources.includes(item["sources"][0]["instanceId"]) && sources.includes("Timewalking")) ||
-              (dungeonSources.includes(item["sources"][0]["instanceId"]) && sources.includes("Dungeons"))))
+            ((TRINKET_SOURCES.other.includes(item["sources"][0]["instanceId"]) && sources.includes("The Rest")) ||
+              (TRINKET_SOURCES.raid.includes(item["sources"][0]["instanceId"]) && sources.includes("Raids")) ||
+              (TRINKET_SOURCES.delves.includes(item["sources"][0]["instanceId"]) && sources.includes("Delves")) ||
+              (TRINKET_SOURCES.timewalking.includes(item["sources"][0]["instanceId"]) && sources.includes("Timewalking")) ||
+              (TRINKET_SOURCES.dungeon.includes(item["sources"][0]["instanceId"]) && sources.includes("Dungeons"))))
         );
       });
     }

--- a/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
+++ b/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
@@ -525,7 +525,7 @@ export default function TrinketAnalysis(props) {
 
               {gameType === "Retail" ? (
                 <Grid item xs={12}>
-                  <Grid container spacing={0} direction="row" justifyContent="flex-end">
+                  <Grid container spacing={0.5} direction="row" justifyContent="flex-end">
                     <Grid item>
                       <Tooltip title={"Alternate Theme"} arrow>
                         <ToggleButton
@@ -534,13 +534,18 @@ export default function TrinketAnalysis(props) {
                           onChange={() => {
                             setTheme(!theme);
                           }}
+                          sx={{ height: 40, width: 40 }}
                         >
                           <VisibilityIcon />
                         </ToggleButton>
                       </Tooltip>
                     </Grid>
                     <Grid item>
-                      <Button variant="contained" onClick={handleDownload}>
+                      <Button 
+                        variant="contained"
+                        onClick={handleDownload}
+                        sx={{ height: 40 }}
+                      >
                         Download JSON
                       </Button>   
                     </Grid>

--- a/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
+++ b/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
@@ -442,7 +442,7 @@ export default function TrinketAnalysis(props) {
   const handleExportMenuClick = (buttonClicked) => {
     if (buttonClicked === "Wowhead Tier List") {
       setDialogOpen(true);
-      setDialogText(exportWowheadTierList(activeTrinkets, props.player.spec));
+      setDialogText(exportWowheadTierList(activeTrinkets));
     } else if (buttonClicked === "Download JSON") {
       handleDownload();
     }

--- a/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
+++ b/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
@@ -25,6 +25,9 @@ import { reforgeIDs } from "General/Modules/TopGear/Report/TopGearExports";
 import TrinketSpecialMentions from "General/Modules/TrinketAnalysis/TrinketSpecialMentions";
 import { downloadJson } from "./TrinketJSONDownload"
 import { getAllTrinketData } from "Retail/Engine/EffectFormulas/Generic/Trinkets/TrinketEffectFormulas.js"
+import GenericDialog from "General/Modules/TopGear/Report/GenericDialog";
+import MenuDropdown from "General/Modules/TopGear/Report/MenuDropdown";
+import { exportWowheadTierList } from "General/Modules/TopGear/Report/TopGearExports";
 
 
 function TabPanel(props) {
@@ -199,7 +202,9 @@ export default function TrinketAnalysis(props) {
   const [tabIndex, setTabIndex] = React.useState(0);
   const [sources, setSources] = React.useState(() => ["The Rest", "Raids", "Dungeons", "Delves"]); //, "LegionTimewalking"
   const [theme, setTheme] = React.useState(false);
-  const [levelCap, setLevelCap] = React.useState(298); 
+  const [levelCap, setLevelCap] = React.useState(298);
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [dialogText, setDialogText] = React.useState(""); 
   const maxLevelMarks = [
     { value: 0, label: "237" },
     { value: 1, label: "250" },
@@ -429,6 +434,21 @@ export default function TrinketAnalysis(props) {
     activeTrinkets.sort((a, b) => (getHighestTrinketScore(finalDB, a, itemLevels.at(-1)) < getHighestTrinketScore(finalDB, b, itemLevels.at(-1)) ? 1 : -1));
   }
 
+  // setup export button menu options
+  let exportOptions = ["Download JSON"];
+  if (window.location.href.includes("localhost") || window.location.href.includes("ptr")) {
+    exportOptions.push("Wowhead Tier List");
+  }
+
+  const handleExportMenuClick = (buttonClicked) => {
+    if (buttonClicked === "Wowhead Tier List") {
+      setDialogOpen(true);
+      setDialogText(exportWowheadTierList(activeTrinkets, props.player.spec));
+    } else if (buttonClicked === "Download JSON") {
+      handleDownload();
+    }
+  };
+
   const trinketText = gameType === "Retail" ? "Hero / Myth trinkets can be upgraded 9 item levels via the new Ascended upgrade system. Hover over ? next to trinkets for more information on them."  :
                                               "Rankings use a sample stat profile, use Top Gear to fine tune results for your specific loadout.";
 
@@ -541,13 +561,11 @@ export default function TrinketAnalysis(props) {
                       </Tooltip>
                     </Grid>
                     <Grid item>
-                      <Button 
-                        variant="contained"
-                        onClick={handleDownload}
+                      <MenuDropdown
+                        handleClicked={handleExportMenuClick}
+                        exportOptions={exportOptions}
                         sx={{ height: 40 }}
-                      >
-                        Download JSON
-                      </Button>   
+                      />
                     </Grid>
                   </Grid>
                 </Grid>
@@ -561,6 +579,11 @@ export default function TrinketAnalysis(props) {
       <div id="qelivead2"></div>
       {/*<TrinketSpecialMentions information={"Demo"} />*/}
       <div style={{ height: 300 }} />
+      <GenericDialog
+        dialogText={dialogText}
+        isDialogOpen={dialogOpen}
+        setDialogOpen={setDialogOpen}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description
- Added "Export" button instead (Taken from TopGear), visible always
- Refactored Top Gear's Export button to create the menu items directly instead of inside of the component + allowed passing in sx 
- Adjusted sizing of theme button to match + spacing in the grid below trinket chart
- Moved "Download JSON" button into export button's menu items (shown always, same as before) and added Tier List + Cheat Sheet with localhost/ptr window location
  <img width="295" height="199" alt="image" src="https://github.com/user-attachments/assets/17d504a1-458b-49b9-bcbe-3ce280362eea" />
- Driveby changed Philosopher trinket to -4 source for crafted
- Refactored sources of trinket in TrinketAnalysis slightly to get an exportable table for the entries. Might be something to move into CONSTANTS anyways?

### Tier List
- Rankings are created with a threshold given off of the top trinket's max ilvl score
- Tooltips only added for trinkets above a specific threshold (currently set to above A tier) or if there is a warning flag, specifically this tier's case, Crucible of Erratic Energies trinket. 
  - Included a `{{REMOVE ME AFTER ADJUSTING TOOLTIPS}}` portion to the beginning so the user can make sure they adjust or add tooltips for these trinkets themselves, or add new ones if they desire. Similar formatting to the wowhead instructions, anyways, for consistency.
- Trinkets outside of the display options are simply quality 1, like crucible and pvp trinkets, etc, but keep themselves as delve flippers. 
<img width="1216" height="959" alt="image" src="https://github.com/user-attachments/assets/68047287-3835-4b89-a6ba-b8470d28252b" />
<img width="778" height="1184" alt="image" src="https://github.com/user-attachments/assets/ce8d4ffb-d8b2-4f45-922b-25e81be803f9" />

### Cheat Sheet
- Pretty standard, similar ranking generation as the Tier List except picks the top 4: top 2 are "Best in Slot" and bottom 2 are "Alternatives".
<img width="628" height="171" alt="image" src="https://github.com/user-attachments/assets/507aebde-875c-4ab7-98df-0de3a680a124" />
<img width="791" height="368" alt="image" src="https://github.com/user-attachments/assets/f2281fb1-e795-422a-a978-234df5b70be7" />