### PR TITLE
Add 285 upgrade breakpoint to trinket chart slider

### DIFF
--- a/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
+++ b/src/General/Modules/TrinketAnalysis/TrinketAnalysis.js
@@ -226,8 +226,9 @@ export default function TrinketAnalysis(props) {
     { value: 1, label: "250" },
     { value: 2, label: "263" },
     { value: 3, label: "276" },
-    { value: 4, label: "289" },
-    { value: 5, label: "298" },
+    { value: 4, label: "285" },
+    { value: 5, label: "289" },
+    { value: 6, label: "298" },
   ]
 
   const handleTabChange = (event, newValue) => {
@@ -488,11 +489,11 @@ export default function TrinketAnalysis(props) {
                   className={classes.slider}
                   style={{ color: "#52af77" }}
                   containerStyle={{ paddingRight: 8 }}
-                  defaultValue={5}
+                  defaultValue={6}
                   step={null}
                   valueLabelDisplay="off"
                   marks={maxLevelMarks} //marks
-                  max={5}
+                  max={6}
                   change={changeLevelCap} //setDungeonDifficulty
                 />
               </div>


### PR DESCRIPTION
With the new Ascendant Voidshard upgrade tracks, Heroic items cap at 285 (up from 276) and Mythic items cap at 298 (up from 289). The slider was missing 285, so the chart could not be capped at the Heroic Ascendant Voidshard breakpoint.