### PR TITLE
Midnight S2: Upgrade Finder Updates

### DIFF
--- a/src/Databases/ItemLevelsDB.ts
+++ b/src/Databases/ItemLevelsDB.ts
@@ -1,32 +1,27 @@
 export const itemLevels: {raid: number[]; dungeon: number[]; pvp: number[]; crafted: number[];} = {
-  raid: [ // Updated for S4.
-    /* ----------------------------------------- Raid Finder ---------------------------------------- */
-    // Slider Value = 0
-    279,
-    292,
-    305,
-    318,
+  // Midnight Season 2 spreadsheet: drop bases, then track caps (LFR/Veteran, Normal/Champion, Heroic/Hero, Mythic/Myth).
+  raid: [
+    /* ----------------------------------------- Drop bases ---------------------------------------- */
+    279, // LFR (Veteran)
+    292, // Normal (Champion)
+    305, // Heroic (Hero)
+    318, // Mythic (Myth) — most bosses; last 2 override higher in engine
 
-    // Fully ugpraded versions
-    298,
-    308,
-    321,
-    334
-
+    /* --------------------------------------- Fully upgraded -------------------------------------- */
+    295, // Veteran max
+    308, // Champion max
+    321, // Hero max
+    334, // Myth 6/6; some bosses drop above this (engine overrides last 2 to 344)
   ],
+  // End-of-run dungeon drops (UF uses MPlusKeyRewards for key → vault/bonus mapping).
   dungeon: [
-    292,
-    295,
-    298,
-    302,
-    305,
-    308,
-    311,
-    315, 
-    318,
-    321,
-    328,
-    334,
+    292, // M0
+    295, // +2/3
+    298, // +4
+    302, // +5
+    305, // +6/7
+    308, // +8/9
+    311, // +10
   ],
   pvp: [
     /* ------------------------------------------ Unranked ------------------------------------------ */

--- a/src/Databases/MPlusKeyRewards.ts
+++ b/src/Databases/MPlusKeyRewards.ts
@@ -1,0 +1,90 @@
+/**
+ * Mythic+ key → loot outcomes for Upgrade Finder (Midnight Season 2 spreadsheet).
+ * Vault and Nebulous Voidcore bonus rolls share the same track/ilvl per key.
+ *
+ * Tracks: Champion →308 · Hero →321 · Myth →334 (6/6); some raid bosses drop above 334
+ */
+
+export type UpgradeTrack = "Champion" | "Hero" | "Myth";
+
+export const TRACK_CAPS: Record<UpgradeTrack, number> = {
+  Champion: 308,
+  Hero: 321,
+  Myth: 334, // 6/6 Myth; some raid bosses drop above this
+};
+
+export type MPlusKeyReward = {
+  index: number;
+  label: string;
+  endIlvl: number;
+  endTrack: UpgradeTrack;
+  vaultIlvl: number;
+  vaultTrack: UpgradeTrack;
+};
+
+export const MPLUS_KEY_REWARDS: MPlusKeyReward[] = [
+  { index: 0, label: "M0", endIlvl: 292, endTrack: "Champion", vaultIlvl: 302, vaultTrack: "Champion" },
+  { index: 1, label: "+2/3", endIlvl: 295, endTrack: "Champion", vaultIlvl: 305, vaultTrack: "Hero" },
+  { index: 2, label: "+4", endIlvl: 298, endTrack: "Champion", vaultIlvl: 308, vaultTrack: "Hero" },
+  { index: 3, label: "+5", endIlvl: 302, endTrack: "Champion", vaultIlvl: 308, vaultTrack: "Hero" },
+  { index: 4, label: "+6", endIlvl: 305, endTrack: "Hero", vaultIlvl: 311, vaultTrack: "Hero" },
+  { index: 5, label: "+7", endIlvl: 305, endTrack: "Hero", vaultIlvl: 315, vaultTrack: "Hero" },
+  { index: 6, label: "+8/9", endIlvl: 308, endTrack: "Hero", vaultIlvl: 315, vaultTrack: "Hero" },
+  { index: 7, label: "+10", endIlvl: 311, endTrack: "Hero", vaultIlvl: 318, vaultTrack: "Myth" },
+];
+
+export const DEFAULT_MPLUS_KEY_INDEX = 7; // +10
+
+/** Map legacy slider indices (which mixed vault ilvls onto the same axis) onto key-only indices. */
+export const UF_DUNGEON_DIFFICULTY_VERSION = 2;
+
+export function migrateUfDungeonDifficulty(stored: number): number {
+  const oldToNew = [0, 1, 2, 3, 4, 6, 7];
+  if (Number.isInteger(stored) && stored >= 0 && stored < oldToNew.length) {
+    return oldToNew[stored];
+  }
+  if (Number.isInteger(stored) && stored >= 0 && stored < MPLUS_KEY_REWARDS.length) {
+    return stored;
+  }
+  return DEFAULT_MPLUS_KEY_INDEX;
+}
+
+/** One-time migrate from the old slider index space; safe to call every mount after version is stamped. */
+export function loadUfDungeonDifficulty(): number {
+  const versionRaw = sessionStorage.getItem("ufDungeonDifficultyVersion");
+  const version = versionRaw ? JSON.parse(versionRaw) : 1;
+  const stored = (() => {
+    const raw = sessionStorage.getItem("ufDungeonDifficulty");
+    if (!raw) return DEFAULT_MPLUS_KEY_INDEX;
+    return JSON.parse(raw);
+  })();
+
+  if (version < UF_DUNGEON_DIFFICULTY_VERSION) {
+    const migrated = migrateUfDungeonDifficulty(stored);
+    sessionStorage.setItem("ufDungeonDifficultyVersion", JSON.stringify(UF_DUNGEON_DIFFICULTY_VERSION));
+    sessionStorage.setItem("ufDungeonDifficulty", JSON.stringify(migrated));
+    return migrated;
+  }
+
+  if (Number.isInteger(stored) && stored >= 0 && stored < MPLUS_KEY_REWARDS.length) {
+    return stored;
+  }
+  return DEFAULT_MPLUS_KEY_INDEX;
+}
+
+export function getMPlusKeyReward(keyIndex: number): MPlusKeyReward {
+  return MPLUS_KEY_REWARDS[keyIndex] ?? MPLUS_KEY_REWARDS[DEFAULT_MPLUS_KEY_INDEX];
+}
+
+/** drop = end-of-run; max = end track cap; bonus = vault/bonus-roll track cap */
+export function getMPlusItemLevel(keyIndex: number, difficultyType: string = "drop"): number {
+  const key = getMPlusKeyReward(keyIndex);
+  if (difficultyType === "max") return TRACK_CAPS[key.endTrack];
+  if (difficultyType === "bonus") return TRACK_CAPS[key.vaultTrack];
+  return key.endIlvl;
+}
+
+export function mplusEndAndVaultSameTrack(keyIndex: number): boolean {
+  const key = getMPlusKeyReward(keyIndex);
+  return key.endTrack === key.vaultTrack;
+}

--- a/src/General/Engine/CONSTANTS.ts
+++ b/src/General/Engine/CONSTANTS.ts
@@ -28,7 +28,7 @@ export const CONSTANTS = {
     seasonalItemConversion: 13, // 6 = S2, 7 = S3, 8 = ??, 9 = S4. This value is used to determine if an item can be catalyzed.
     currentRaidIDs: [1320, 1317], // This should be an array even with one raid. This value is used in various array specific functions. 1317 = new world boss
     currentDungeonIDs: [1322, 1311, 1304, 1309, 1313, 1041, 1202, 1030],
-    fullItemLevels: [250, 253, 256, 259, 263, 266, 269, 272, 276, 279, 282, 285, 289, 292, 295, 298, 302, 305, 308, 311, 315, 318, 321, 324, 328, 331, 334],
+    fullItemLevels: [250, 253, 256, 259, 263, 266, 269, 272, 276, 279, 282, 285, 289, 292, 295, 298, 302, 305, 308, 311, 315, 318, 321, 324, 328, 331, 334, 337, 341, 344],
     itemLevelCaps: { Adventurer: 282, Veteran: 295, Champion: 308, Hero: 321, Myth: 334, "Runed Crafted": 318, "Gilded Crafted": 331 },
     seasonID: 37,
     tierNames: { // @deprecated.

--- a/src/General/Engine/ItemUtilities.ts
+++ b/src/General/Engine/ItemUtilities.ts
@@ -435,7 +435,6 @@ export function filterItemListByDropLoc(itemList: any[], sourceInstance: number,
   let temp = itemList.filter(function (item) {
     //else if (sourceInstance === -17 && pvpRank === 5 && ["1H Weapon", "2H Weapon", "Offhand", "Shield"].includes(item.slot)) expectedItemLevel += 7;
     //console.log("loc: " + loc + " vs " + item.dropLoc + " diff: " + difficulty + " vs " + item.dropDifficulty + " source: " + sourceInstance + " vs " + item.source.instanceId + " boss: " + sourceBoss + " vs " + item.source.encounterId)
-    console.log("Drop type: " + dropType + " vs " + item.dropType)
     return loc === item.dropLoc && difficulty === item.dropDifficulty && dropType === item.dropType && ((item.source.instanceId == sourceInstance && item.source.encounterId == sourceBoss) || (item.source.instanceId == sourceInstance && sourceBoss == 0));
   });
   return temp;
@@ -501,12 +500,15 @@ export function getDifferentialByID(diffList: any, id: number, level: number) {
 }
 
 // Returns the number of upgrades (score > 0) for a given section.
-export const getNumUpgrades = (items: any[], raidID : number, bossID : number, difficultyID? : number) => {
-  if (difficultyID) return items.filter((item: any) => item.source.instanceId === raidID && item.source.encounterId === bossID && item.dropDifficulty === difficultyID && item.score > 0).length;
-  else {
-    return items.filter((item: any) => item.source.instanceId === raidID && item.source.encounterId === bossID && item.score > 0).length;
-
-  }
+// uniqueByItem: count each item id once across drop/max/bonus variants (for accordion headers).
+export const getNumUpgrades = (items: any[], raidID : number, bossID : number, difficultyID? : number, uniqueByItem: boolean = false) => {
+  const filtered = items.filter((item: any) => {
+    if (item.source.instanceId !== raidID || item.source.encounterId !== bossID || !(item.score > 0)) return false;
+    if (difficultyID !== undefined && item.dropDifficulty !== difficultyID) return false;
+    return true;
+  });
+  if (uniqueByItem) return new Set(filtered.map((item: any) => item.item)).size;
+  return filtered.length;
 }
 
 // Returns true or false based on whether an ID exists in our item database.

--- a/src/General/Modules/UpgradeFinder/Panels/PanelMythicPlus.js
+++ b/src/General/Modules/UpgradeFinder/Panels/PanelMythicPlus.js
@@ -1,14 +1,14 @@
 import React from "react";
 import { dungeonStyles, sharedAccordionStyles, sharedAccordionSummaryStyles, sharedAccordionDetailsStyles } from "./PanelStyles";
-import { Typography, Grid, Divider, AppBar, Tabs, Tab } from "@mui/material";
+import { Typography, Grid, Divider, AppBar } from "@mui/material";
 import ItemUpgradeCard from "./ItemUpgradeCard";
 import DungeonHeaderIcons from "General/Modules/IconFunctions/DungeonHeaderIcons";
 import "./Panels.css";
 import { useTranslation } from "react-i18next";
-import { filterItemListBySource, getDifferentialByID, getNumUpgrades, filterItemListByDropLoc } from "../../../Engine/ItemUtilities";
+import { filterItemListByDropLoc, getDifferentialByID, getNumUpgrades } from "../../../Engine/ItemUtilities";
 import { filterClassicItemListBySource } from "../../../Engine/ItemUtilitiesClassic";
 import { encounterDB } from "../../../../Databases/InstanceDB";
-import { itemLevels } from "../../../../Databases/ItemLevelsDB";
+import { getMPlusKeyReward, mplusEndAndVaultSameTrack, TRACK_CAPS } from "../../../../Databases/MPlusKeyRewards";
 import { useSelector } from "react-redux";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -16,28 +16,34 @@ import UFAccordion from "./ufComponents/ufAccordian";
 import UFAccordionSummary from "./ufComponents/ufAccordianSummary";
 import UFTabPanel from "./ufComponents/ufTabPanel";
 
+function sectionHeaderStyle(highlighted) {
+  if (highlighted) {
+    return {
+      background: "linear-gradient(180deg, rgba(242, 191, 89, 0.16) 0%, rgba(242, 191, 89, 0.08) 100%)",
+      borderRadius: 8,
+      padding: "7px 12px",
+      border: "1px solid rgba(242, 191, 89, 0.34)",
+      boxShadow: "inset 0 0 0 1px rgba(242, 191, 89, 0.14)",
+    };
+  }
+  return {
+    background: "rgba(255, 255, 255, 0.06)",
+    borderRadius: 8,
+    padding: "6px 10px",
+  };
+}
+
 export default function MythicPlusGearContainer(props) {
   const classes = dungeonStyles();
   const { t, i18n } = useTranslation();
   const currentLanguage = i18n.language;
-  const itemList = props.itemList;
-
   const itemDifferentials = props.itemDifferentials;
   const difficulty = props.playerSettings.dungeon;
   const gameType = useSelector((state) => state.gameType);
+  const keyReward = getMPlusKeyReward(difficulty);
+  const sameTrack = mplusEndAndVaultSameTrack(difficulty);
 
-  function a11yProps(index) {
-    return {
-      id: `simple-tab-${index}`,
-      "aria-controls": `simple-tabpanel-${index}`,
-    };
-  }
-
-  const [tabvalue, setTabValue] = React.useState(0);
-  const handleTabChange = (event, newValue) => {
-    setTabValue(newValue);
-  };
-
+  const [tabvalue] = React.useState(0);
 
   const contentGenerator = (gameType) => {
     return (
@@ -53,19 +59,6 @@ export default function MythicPlusGearContainer(props) {
                 }}
                 elevation={1}
               >
-                {/*<Tabs
-                  value={tabvalue}
-                  onChange={handleTabChange} 
-                  aria-label="simple tabs example"
-                  variant="fullWidth"
-                  style={{ borderRadius: 4, border: "1px solid rgba(255, 255, 255, 0.22)" }}
-                  TabIndicatorProps={{ style: { backgroundColor: "#F2BF59" } }}
-              > */}
-                  {/* ------------------------------------------ Mythic + ------------------------------------------*/}
-                  {/*<Tab className={classes.mythicPlusHeader} label={"Mythic +"} {...a11yProps(0)} /> */}
-                  {/* ------------------------------------------ Mythic 0 ------------------------------------------ */}
-                  {/*<Tab className={classes.mythicHeader} label={"Dawn of the Infinite"} {...a11yProps(1)} /> */}
-                {/*</Tabs> */}
               </AppBar>
             </Grid>
             <Grid item xs={12}>
@@ -77,21 +70,20 @@ export default function MythicPlusGearContainer(props) {
                         <UFAccordion
                           key={encounterDB["-1"][gameType][key] + "-accordian" + i}
                           elevation={0}
-                          defaultExpanded={true}
-                            style={sharedAccordionStyles}
+                          defaultExpanded={false}
+                          style={sharedAccordionStyles}
                         >
                           <UFAccordionSummary
                             expandIcon={<ExpandMoreIcon />}
                             aria-controls="panel1a-content"
                             id="panel1a-header"
-                              style={sharedAccordionSummaryStyles}
+                            style={sharedAccordionSummaryStyles}
                           >
                             <Typography
                               variant="h6"
                               color="primary"
                               align="left"
                               style={{
-                                // backgroundColor: "#35383e",
                                 borderRadius: "4px 4px 0px 0px",
                                 display: "flex",
                               }}
@@ -99,17 +91,47 @@ export default function MythicPlusGearContainer(props) {
                               <img style={{ height: 36, width: 56, verticalAlign: "middle" }} src={DungeonHeaderIcons(key)} alt={encounterDB["-1"][gameType][key]} />
                               <Divider flexItem orientation="vertical" style={{ margin: "0px 5px 0px 0px" }} />
                               {encounterDB["-1"][gameType][key]} -{" "}
-                              {
-                                getNumUpgrades(itemDifferentials, -1, key, difficulty)
-                              }{" "}
-                              Upgrades
+                              {getNumUpgrades(itemDifferentials, -1, key, difficulty, true)} Upgrades
                             </Typography>
                           </UFAccordionSummary>
                           <AccordionDetails style={sharedAccordionDetailsStyles}>
-                            <Grid xs={12} container spacing={1}>
-                              {[...filterItemListByDropLoc(itemDifferentials, -1, key, "Dungeon", difficulty)].map((item, index) => (
-                                <ItemUpgradeCard key={index} item={item} itemDifferential={getDifferentialByID(itemDifferentials, item.id, item.level)} slotPanel={false} />
-                              ))}
+                            <Grid item xs={12} sm container direction="row" spacing={1}>
+                              <Grid item xs={12} container spacing={1}>
+                                <Grid item xs={12}>
+                                  <div style={sectionHeaderStyle(true)}>
+                                    <Typography variant="h6" color="primary" align="left">
+                                      {keyReward.label} - Upgraded Vault / Bonus Rolls ({TRACK_CAPS[keyReward.vaultTrack]} {keyReward.vaultTrack})
+                                    </Typography>
+                                  </div>
+                                </Grid>
+                                {[...filterItemListByDropLoc(itemDifferentials, -1, key, "Dungeon", difficulty, "bonus")].map((item, index) => (
+                                  <ItemUpgradeCard key={"bonus-" + index} item={item} itemDifferential={getDifferentialByID(itemDifferentials, item.item, item.level)} slotPanel={false} />
+                                ))}
+                              </Grid>
+
+                              {!sameTrack ? (
+                                <Grid item xs={12} container spacing={1}>
+                                  <Grid item xs={12}>
+                                    <Typography variant="h6" color="primary" align="left" style={sectionHeaderStyle(false)}>
+                                      {keyReward.label} - Upgraded End of Run ({TRACK_CAPS[keyReward.endTrack]} {keyReward.endTrack})
+                                    </Typography>
+                                  </Grid>
+                                  {[...filterItemListByDropLoc(itemDifferentials, -1, key, "Dungeon", difficulty, "max")].map((item, index) => (
+                                    <ItemUpgradeCard key={"max-" + index} item={item} itemDifferential={getDifferentialByID(itemDifferentials, item.item, item.level)} slotPanel={false} />
+                                  ))}
+                                </Grid>
+                              ) : null}
+
+                              <Grid item xs={12} container spacing={1}>
+                                <Grid item xs={12}>
+                                  <Typography variant="h6" color="primary" align="left" style={sectionHeaderStyle(false)}>
+                                    {keyReward.label} - End of Run ({keyReward.endIlvl} {keyReward.endTrack})
+                                  </Typography>
+                                </Grid>
+                                {[...filterItemListByDropLoc(itemDifferentials, -1, key, "Dungeon", difficulty, "drop")].map((item, index) => (
+                                  <ItemUpgradeCard key={"drop-" + index} item={item} itemDifferential={getDifferentialByID(itemDifferentials, item.item, item.level)} slotPanel={false} />
+                                ))}
+                              </Grid>
                             </Grid>
                           </AccordionDetails>
                         </UFAccordion>
@@ -118,57 +140,6 @@ export default function MythicPlusGearContainer(props) {
                   </Grid>
                 </div>
               </UFTabPanel>
-
-              {/*<UFTabPanel key={"panel1"} value={tabvalue} index={1}>
-                <div className={classes.panel}>
-                  <Grid container spacing={1}>
-                    <Grid item xs={12}>
-                      {encounterDB[1209].bossOrder.map((key, i) => (
-                        <UFAccordion
-                          key={encounterDB[1209][key].name[currentLanguage] + "-accordian" + i}
-                          elevation={0}
-                          style={{
-                            backgroundColor: "rgba(255, 255, 255, 0.12)",
-                          }}
-                        >
-                          <UFAccordionSummary
-                            expandIcon={<ExpandMoreIcon />}
-                            aria-controls="panel1a-content"
-                            id="panel1a-header"
-                            style={{
-                              verticalAlign: "middle",
-                            }}
-                          >
-                            <Typography
-                              variant="h6"
-                              color="primary"
-                              align="left"
-                              style={{
-                                // backgroundColor: "#35383e",
-                                borderRadius: "4px 4px 0px 0px",
-                                display: "flex",
-                              }}
-                            >
-                              {bossHeaders(key, { height: 36, verticalAlign: "middle" }, "UpgradeFinder")}
-                              <Divider flexItem orientation="vertical" style={{ margin: "0px 5px 0px 0px" }} />
-                              {encounterDB[1209][key].name[currentLanguage]} -{" "}
-                              {[...filterItemListBySource(itemDifferentials, 1209, key, 441)].map((item) => getDifferentialByID(itemDifferentials, item.id, item.level)).filter((item) => item !== 0).length}{" "}
-                              Upgrades
-                            </Typography>
-                          </UFAccordionSummary>
-                          <AccordionDetails style={{ backgroundColor: "#191c23" }}>
-                            <Grid xs={12} container spacing={1}>
-                              {[...filterItemListBySource(itemDifferentials, 1209, key, 441)].map((item, index) => (
-                                <ItemUpgradeCard key={index} item={item} itemDifferential={getDifferentialByID(itemDifferentials, item.id, item.level)} slotPanel={false} />
-                              ))}
-                            </Grid>
-                          </AccordionDetails>
-                        </UFAccordion>
-                      ))}
-                    </Grid>
-                  </Grid>
-                </div>
-                    </UFTabPanel> */}
             </Grid>
           </Grid>
         </div>
@@ -198,7 +169,6 @@ export default function MythicPlusGearContainer(props) {
             color="primary"
             align="left"
             style={{
-              // backgroundColor: "#35383e",
               borderRadius: "4px 4px 0px 0px",
               display: "flex",
             }}

--- a/src/General/Modules/UpgradeFinder/Panels/PanelMythicPlus.js
+++ b/src/General/Modules/UpgradeFinder/Panels/PanelMythicPlus.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { dungeonStyles, sharedAccordionStyles, sharedAccordionSummaryStyles, sharedAccordionDetailsStyles } from "./PanelStyles";
-import { Typography, Grid, Divider, AppBar } from "@mui/material";
+import { Typography, Grid, Divider } from "@mui/material";
 import ItemUpgradeCard from "./ItemUpgradeCard";
 import DungeonHeaderIcons from "General/Modules/IconFunctions/DungeonHeaderIcons";
 import "./Panels.css";
@@ -14,7 +14,6 @@ import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import UFAccordion from "./ufComponents/ufAccordian";
 import UFAccordionSummary from "./ufComponents/ufAccordianSummary";
-import UFTabPanel from "./ufComponents/ufTabPanel";
 
 function sectionHeaderStyle(highlighted) {
   if (highlighted) {
@@ -43,29 +42,15 @@ export default function MythicPlusGearContainer(props) {
   const keyReward = getMPlusKeyReward(difficulty);
   const sameTrack = mplusEndAndVaultSameTrack(difficulty);
 
-  const [tabvalue] = React.useState(0);
-
   const contentGenerator = (gameType) => {
     return (
       <Grid item xs={12}>
         <div className={classes.header}>
           <Grid item container spacing={1}>
             <Grid item xs={12}>
-              <AppBar
-                position="static"
-                style={{
-                  backgroundColor: "#000",
-                  borderRadius: "4px 4px 4px 4px",
-                }}
-                elevation={1}
-              >
-              </AppBar>
-            </Grid>
-            <Grid item xs={12}>
-              <UFTabPanel key={"panel2"} value={tabvalue} index={0}>
-                <div className={classes.panel}>
-                  <Grid container spacing={1}>
-                    <Grid item xs={12}>
+              <div className={classes.panel}>
+                <Grid container spacing={1}>
+                  <Grid item xs={12}>
                       {encounterDB["-1"][gameType].bossOrderMythicPlus.map((key, i) => (
                         <UFAccordion
                           key={encounterDB["-1"][gameType][key] + "-accordian" + i}
@@ -136,10 +121,9 @@ export default function MythicPlusGearContainer(props) {
                           </AccordionDetails>
                         </UFAccordion>
                       ))}
-                    </Grid>
                   </Grid>
-                </div>
-              </UFTabPanel>
+                </Grid>
+              </div>
             </Grid>
           </Grid>
         </div>

--- a/src/General/Modules/UpgradeFinder/UpgradeFinder.test.js
+++ b/src/General/Modules/UpgradeFinder/UpgradeFinder.test.js
@@ -29,5 +29,3 @@ describe("LFR Item Level tests", () => {
         expect(getSetItemLevel(kazzara, lfrSettings, 0, 202612)).toEqual(408);
     }) */
 })
-
-

--- a/src/General/Modules/UpgradeFinder/UpgradeFinderEngine.js
+++ b/src/General/Modules/UpgradeFinder/UpgradeFinderEngine.js
@@ -5,6 +5,7 @@ import { getItemDB, calcStatsAtLevel, getItemLevelBoost, getVeryRareItemLevelBoo
 import UpgradeFinderResult from "./UpgradeFinderResult";
 import { apiSendUpgradeFinder } from "../SetupAndMenus/ConnectionUtilities";
 import { itemLevels } from "../../../Databases/ItemLevelsDB";
+import { getMPlusItemLevel, getMPlusKeyReward, mplusEndAndVaultSameTrack } from "../../../Databases/MPlusKeyRewards";
 import { getSetting } from "Retail/Engine/EffectFormulas/EffectUtilities"
 import { CONSTANTS } from "General/Engine/CONSTANTS";
 /*
@@ -146,12 +147,13 @@ export function getSetItemLevel(itemSource, playerSettings, difficultyType = "dr
       itemLevel = itemLevels.raid[difficulty + 4]
     }
     if (difficultyType === "bonus") {
-      if (difficulty === 3) itemLevel = itemLevels.raid[difficulty + 4] // Mythic is the same as Mythic Max.
-      else itemLevel = itemLevels.raid[difficulty + 5]; // Go up one difficulty and then Max.
+      // Bonus roll / vault track at cap. LFR→Champion, Normal→Hero, Heroic→Myth (318 base), Mythic stays Myth.
+      if (difficulty === 3) itemLevel = itemLevels.raid[difficulty + 4];
+      else itemLevel = itemLevels.raid[difficulty + 5];
     }
 
     if (difficulty === 3 && [2895, 2883].includes(bossID)) {
-      itemLevel = 344 // 9/6 Mythic
+      itemLevel = 344 // Last 2 Mythic bosses
     }
     else if (difficultyType === "drop") {
       itemLevel += getItemLevelBoost(bossID, difficulty)// + getVeryRareItemLevelBoost(itemID, bossID, difficulty);
@@ -166,8 +168,8 @@ export function getSetItemLevel(itemSource, playerSettings, difficultyType = "dr
   }
 
   else if (instanceID === -1) {
-    //if ([1201, 1202, 1203, 1198].includes(bossID)) itemLevel = 372; // M0 only dungeons.
-    itemLevel = itemLevels.dungeon[playerSettings.dungeon];
+    // Mythic+: drop = end-of-run, max = end track cap, bonus = vault/bonus-roll track cap
+    itemLevel = getMPlusItemLevel(playerSettings.dungeon, difficultyType);
   }
   else if (instanceID === -4) {
     // Crafted
@@ -264,16 +266,24 @@ function buildItemPossibilities(player, contentType, playerSettings, settings) {
 
 
       } else if (primarySource === -1) {
-        // M+ Dungeons
+        // M+ Dungeons — same contract as raid: drop / max / bonus (vault + voidcore share bonus track)
         // Edit which dungeons are in-season in the CONSTANTS file.
         if (CONSTANTS.currentDungeonIDs.includes(encounter)) {
-          const itemLevel = getSetItemLevel(itemSources, playerSettings, 0, rawItem.slot);
-          const item = buildItem(player, contentType, rawItem, itemLevel, rawItem.sources[0], settings, playerSettings);
-          item.dropLoc = "Dungeon";
-          item.dropDifficulty = playerSettings.dungeon;
-          item.dropDifficultyTxt = "";
-          item.quality = 4;
-          itemPoss.push(item);
+          const keyReward = getMPlusKeyReward(playerSettings.dungeon);
+          const dungeonStates = mplusEndAndVaultSameTrack(playerSettings.dungeon)
+            ? ["drop", "bonus"]
+            : ["drop", "max", "bonus"];
+
+          dungeonStates.forEach((dungeonState) => {
+            const itemLevel = getSetItemLevel(itemSources, playerSettings, dungeonState, rawItem.slot);
+            const item = buildItem(player, contentType, rawItem, itemLevel, rawItem.sources[0], settings, playerSettings);
+            item.quality = 4;
+            item.dropLoc = "Dungeon";
+            item.dropDifficulty = playerSettings.dungeon;
+            item.dropType = dungeonState;
+            item.dropDifficultyTxt = keyReward.label;
+            itemPoss.push(item);
+          });
         }
         else if ([1267, 1272, 1210, 1268].includes(encounter)) {
           // M0

--- a/src/General/Modules/UpgradeFinder/UpgradeFinderFront.js
+++ b/src/General/Modules/UpgradeFinder/UpgradeFinderFront.js
@@ -14,6 +14,7 @@ import CharacterPanel from "../CharacterPanel/CharacterPanel";
 import { generateReportCode } from "General/Modules/TopGear/Engine/TopGearEngineShared";
 import ReactGA from "react-ga";
 import { itemLevels } from "Databases/ItemLevelsDB";
+import { MPLUS_KEY_REWARDS, getMPlusKeyReward, loadUfDungeonDifficulty } from "Databases/MPlusKeyRewards";
 import { trackPageView } from "Analytics";
 import IconHeader from "./IconHeader";
 
@@ -176,23 +177,6 @@ const sendReport = (shortReport) => {
 
 
 
-const mythicPlusLevels = [
-  { value: 292, label: "M0" },
-  { value: 295, label: "+2/3" },
-  { value: 298, label: "+4" },
-  { value: 302, label: "+5" },
-  { value: 305, label: "+6/7" },
-  { value: 308, label: "+8/9" },
-  { value: 311, label: "+10" },
-  { value: 315, label: "Vault" },
-  { value: 318, label: "" },
-  { value: 321, label: "" },
-  { value: 328, label: "" },
-  { value: 334, label: "" },
-  // { value: 285, label: "" },
-  // { value: 289, label: "" },
-]
-
 const getSessionStorageOrDefault = (key, defaultValue) => {
   const stored = sessionStorage.getItem(key);
   if (!stored) {
@@ -224,7 +208,10 @@ export default function UpgradeFinderFront(props) {
     // Keep only one value in case older session data contains two selections.
     return [stored[stored.length - 1]];
   });
-  const [ufDungeonDifficulty, setUfDungeonDifficulty] = useState(() => getSessionStorageOrDefault("ufDungeonDifficulty", gameType === "Retail" ? 6 : 1));
+  const [ufDungeonDifficulty, setUfDungeonDifficulty] = useState(() => {
+    if (gameType !== "Retail") return getSessionStorageOrDefault("ufDungeonDifficulty", 1);
+    return loadUfDungeonDifficulty();
+  });
   const [ufPvPRank, setUfPvPRank] = useState(() => getSessionStorageOrDefault("ufPvPRank", 0));
   const [ufCraftedLevel, setUfCraftedLevel] = useState(() => Math.min(getSessionStorageOrDefault("ufCraftedLevel", 2), 2));
   const [ufCraftedStats, setUfCraftedStats] = useState(() => getSessionStorageOrDefault("ufCraftedStats", "Crit / Haste"));
@@ -273,8 +260,8 @@ export default function UpgradeFinderFront(props) {
     setUfCraftedLevel(newLevel);
   }
 
-  const setDungeonDifficulty = (event, difficulty) => {
-    if (difficulty <= (mythicPlusLevels.length - 1) && difficulty >= 0) setUfDungeonDifficulty(difficulty);
+  const setDungeonDifficulty = (difficulty) => {
+    if (difficulty <= MPLUS_KEY_REWARDS.length - 1 && difficulty >= 0) setUfDungeonDifficulty(difficulty);
   };
 
   const setBCDungeonDifficulty = (event, difficulty) => {
@@ -348,15 +335,7 @@ export default function UpgradeFinderFront(props) {
           "Hit Go at the bottom of the page.",
         ];
 
-  const marks = mythicPlusLevels.map((level, index) => {
-    return { value: index,
-      label: (
-        <div className={classes.labels}>
-          <div>{level.value}</div>
-          <div>{level.label}</div>
-        </div>
-  )};
-  });
+  const selectedMPlusKey = getMPlusKeyReward(ufDungeonDifficulty);
 
   const [dungeonBC, setDungeonBC] = React.useState("Heroic");
 
@@ -397,7 +376,7 @@ export default function UpgradeFinderFront(props) {
 
   const getSimCStatus = (player) => {
     if (player.activeItems.length === 0) return "Missing";
-    else if (checkCharacterValid(player) === false) return "Invalid";
+    else if (checkCharacterValid(player, gameType) === false) return "Invalid";
     else return "Good";
   };
 
@@ -496,30 +475,43 @@ export default function UpgradeFinderFront(props) {
           <Grid item xs={12}>
             <Paper elevation={3} sx={{ textAlign: "center", width: { xs: "100%", sm: "80%" }, margin: "auto" }}>
               <div style={{ padding: 8 }}>
-              <Grid container justifyContent="center" spacing={1}>
-                <Grid item xs={12}>
-                <IconHeader
+                <Grid container justifyContent="center" spacing={1}>
+                  <Grid item xs={12}>
+                    <IconHeader
                       icon={require("Images/inv_relics_hourglass.jpg")}
                       alt="M+ Logo"
                       text={"Mythic+ Key Level"}
-                      />
-                  <Grid item xs={12}>
-                    <Typography align="center">
-                      {t("UpgradeFinderFront.MythicPlusBody")}
-                    </Typography>
+                    />
+                    <Grid item xs={12}>
+                      <Typography align="center">{t("UpgradeFinderFront.MythicPlusBody")}</Typography>
+                    </Grid>
                   </Grid>
                 </Grid>
-              </Grid>
-                <UpgradeFinderSlider
-                  className={classes.slider}
-                  style={{ color: "#52af77" }}
-                  value={ufDungeonDifficulty}
-                  step={null}
-                  valueLabelDisplay="off"
-                  marks={marks}
-                  max={mythicPlusLevels.length - 1}
-                  change={setDungeonDifficulty}
-                />
+
+                <Grid container justifyContent="center" spacing={1} columns={8} className={classes.difficultyGrid}>
+                  {MPLUS_KEY_REWARDS.map((key) => (
+                    <Grid item xs={2} key={key.index}>
+                      <ToggleButton
+                        classes={{
+                          root: classes.difficultyToggle,
+                          selected: classes.difficultyToggleSelected,
+                        }}
+                        value="check"
+                        fullWidth
+                        selected={ufDungeonDifficulty === key.index}
+                        onChange={() => {
+                          setDungeonDifficulty(key.index);
+                        }}
+                      >
+                        {key.label}
+                      </ToggleButton>
+                    </Grid>
+                  ))}
+                </Grid>
+
+                <Typography align="center" style={{ marginTop: 12, color: "rgba(255, 255, 255, 0.78)", fontSize: "0.9rem" }}>
+                  {`End of run: ${selectedMPlusKey.endIlvl} ${selectedMPlusKey.endTrack} · Vault / Bonus: ${selectedMPlusKey.vaultIlvl} ${selectedMPlusKey.vaultTrack}`}
+                </Typography>
               </div>
             </Paper>
           </Grid>

--- a/src/locale/en/translate.json
+++ b/src/locale/en/translate.json
@@ -606,7 +606,7 @@
     "UpgradeFinderFront": {
       "Header": "Upgrade Finder",
       "HelpText": "Find your next item with instance-by-instance and slot-by-slot item lists, all based on your specific character.",
-      "MythicPlusBody": "Use the slider to select dungeon item level",
+      "MythicPlusBody": "Select a Mythic+ key level to check for upgrades.",
       "MythicPlusHeader": "Mythic Plus Key Level",
       "PvPBody": "Select  your Rating",
       "PvPHeader": "PvP Rating",


### PR DESCRIPTION
# Upgrade Finder Updates

## Mythic+ Front Panel
- Updated display to closely mirror the update Raid panel
- Replaced slider with key level buttons
- Now includes multiple item level indicators: drop, vault and bonus roll

## Results
- Each dungeon is split into up to 3 variations: drop, max upgraded drop, and max vault/bonus roll
- Each dungeon is auto collapsed to preserve display

## Notes / Follow up
- Item levels leaked out into some new files, this should be cleaned up and consolidated further so that it limits the number of files needed to update when a new season starts
- Hard coded strings for track names 🥴 
- Upgrades by Slot is a disaster :(

## Screenshots
<img width="934" height="255" alt="image" src="https://github.com/user-attachments/assets/393b7ecc-87d9-425e-b1c0-3c45b9c1f735" />
<img width="1307" height="911" alt="image" src="https://github.com/user-attachments/assets/065d95d9-9662-406a-b145-5e4c48f61fd2" />
