### PR TITLE
fix issue with catalyzed items not retaining source secondaries/cantrips

### DIFF
--- a/src/General/Items/GearImport/SimCImportEngine.ts
+++ b/src/General/Items/GearImport/SimCImportEngine.ts
@@ -475,6 +475,7 @@ export function processItem(line: string, player: Player, contentType: contentTy
     missiveStats: string[];
     effect?: ItemEffect | null;
     itemConversion?: number;
+    redirectedBaseStats?: number;
   }
 
   let protoItem: ProtoItem = {
@@ -522,6 +523,7 @@ export function processItem(line: string, player: Player, contentType: contentTy
     else if (info.includes("gem_id=")) gemID = info.split("=")[1].split("/");
     else if (info.includes("enchant_id=")) enchantID = parseInt(info.split("=")[1]);
     else if (info.includes("titan_disc_id=")) titanDisc = parseInt(info.split("=")[1]);
+    else if (info.includes("redirected_base_stats=")) protoItem.redirectedBaseStats = parseInt(info.split("=")[1]);
     else if (info.includes("id=") && !(info.includes("gem_bonus_id="))) protoItem.id = parseInt(info.split("=")[1]);
     else if (info.includes("drop_level=")) dropLevel = parseInt(info.split("=")[1]);
     else if (info.includes("crafted_stats=")) {
@@ -692,10 +694,14 @@ export function processItem(line: string, player: Player, contentType: contentTy
   if (protoItem.level > 50 && protoItem.id !== 0 && getItem(protoItem.id) !== "" && isSuitable) {
 
 
-    let itemAllocations = getItemAllocations(protoItem.id, protoItem.missiveStats);
+    const redirectedId = protoItem.redirectedBaseStats || 0;
+    const useRedirectedStats = Boolean(redirectedId && getItem(redirectedId));
+    const statSourceId = useRedirectedStats ? redirectedId : protoItem.id;
+
+    let itemAllocations = getItemAllocations(statSourceId, protoItem.missiveStats);
     itemAllocations = Object.keys(specialAllocations).length > 0 ? compileStats(itemAllocations, specialAllocations) : itemAllocations;
     
-    let item = new Item(protoItem.id, "", protoItem.slot, protoItem.sockets || checkDefaultSocket(protoItem.id), protoItem.tertiary, 0, protoItem.level, bonusIDS);
+    let item = new Item(protoItem.id, "", protoItem.slot, protoItem.sockets || checkDefaultSocket(protoItem.id), protoItem.tertiary, 0, protoItem.level, bonusIDS, "Retail", useRedirectedStats ? redirectedId : 0);
     if (craftedIDs) item.craftedStats = craftedIDs;
     // Make some further changes to our item based on where it's located and if it's equipped.
     item.vaultItem = type === "Vault";
@@ -711,7 +717,8 @@ export function processItem(line: string, player: Player, contentType: contentTy
     if (Object.keys(itemBonusStats).length > 0) item.addStats(itemBonusStats);
 
     // Special effects. Note we handle them here instead of in the items constructor in case the player has added an effect to an item like an Embellishment.
-    item.effect = protoItem.effect ? protoItem.effect : getItemProp(protoItem.id, "effect");
+    // Post-12.1 catalyzed pieces keep the source item's secondaries and cantrips (redirected_base_stats).
+    item.effect = protoItem.effect ? protoItem.effect : getItemProp(statSourceId, "effect");
 
     if (item.vaultItem) item.uniqueEquip = "vault";
     else if (protoItem.uniqueTag !== "") item.uniqueEquip = protoItem.uniqueTag;

--- a/src/General/Items/Item.ts
+++ b/src/General/Items/Item.ts
@@ -86,6 +86,7 @@ export class Item {
     if (getItemProp(id, "offspecWeapon", gameType)) this.flags.push("offspecWeapon");
     this.bonusIDS = bonusIDS || "";
     this.quality = getItemProp(id, "quality", gameType);
+    if (catalyzedID) this.catalyzedID = catalyzedID;
 
     if (gameType === "Classic") {
       const sockets = getItemProp(id, "sockets", gameType);

--- a/src/General/Modules/CharacterPanel/CharacterPanel.tsx
+++ b/src/General/Modules/CharacterPanel/CharacterPanel.tsx
@@ -336,7 +336,7 @@ export default function CharacterPanel(props: Props) {
                       .filter((key) => key.isEquipped === true)
                       .map((key, i) => (
                         <Grid item key={i}>
-                          <WowheadTooltip type="item" id={key.id} level={key.level} bonusIDS={key.bonusIDS} domain={wowheadDom}>
+                          <WowheadTooltip type="item" id={key.id} level={key.level} bonusIDS={key.bonusIDS} catalyzedID={key.catalyzedID} domain={wowheadDom}>
                             <img
                               style={{
                                 height: 22,
@@ -395,7 +395,7 @@ export default function CharacterPanel(props: Props) {
                       .filter((key) => key.isEquipped === true)
                       .map((key, i) => (
                         <Grid item key={i}>
-                          <WowheadTooltip type="item" id={key.id} level={key.level} bonusIDS={key.bonusIDS} domain={wowheadDom}>
+                          <WowheadTooltip type="item" id={key.id} level={key.level} bonusIDS={key.bonusIDS} catalyzedID={key.catalyzedID} domain={wowheadDom}>
                             <img
                               style={{
                                 height: 22,

--- a/src/General/Modules/Player/Player.js
+++ b/src/General/Modules/Player/Player.js
@@ -265,7 +265,7 @@ export class Player {
 
     if (temp.length > 0) {
       const match = temp[temp.length - 1];
-      const newItem = new Item(match.id, "", slot, originalItem.socket, originalItem.tertiary, 0, originalItem.level, "");
+      const newItem = new Item(match.id, "", slot, originalItem.socket, originalItem.tertiary, 0, originalItem.level, "", "Retail", originalItem.id);
       Object.assign(newItem, { isCatalystItem: true });
       newItem.stats = originalItem.stats;
       newItem.active = true;

--- a/src/General/Modules/UpgradeFinder/CurrentlyEquippedPanel.js
+++ b/src/General/Modules/UpgradeFinder/CurrentlyEquippedPanel.js
@@ -40,6 +40,7 @@ export default function EquippedItems({ items, gameType, contentType = "Raid" })
               id={item.id}
               level={item.level}
               bonusIDS={item.bonusIDS}
+              catalyzedID={item.catalyzedID}
               domain={gameType === "Retail" ? "en" : "mop-classic"}
             >
               <Box


### PR DESCRIPTION
## Live
<img width="1232" height="132" alt="image" src="https://github.com/user-attachments/assets/262c361f-8208-4814-8ea8-f6bfe21a94c1" />

## Fix
<img width="915" height="148" alt="image" src="https://github.com/user-attachments/assets/53b75e77-8aa3-46a8-ac1c-faab3524a744" />

### SimC Import
```
# Khay - Holy - 2026-08-18 02:22 - US/Sargeras
# SimC Addon 12.1.0-02
# WoW 12.1.0.69382, TOC 120100
# Requires SimulationCraft 1000-01 or newer

paladin="Khay"
level=90
race=human
region=us
server=sargeras
role=attack
professions=blacksmithing=93/enchanting=83
spec=holy
# loot_spec=holy

talents=CEEAzbn3egSOtoSwvPw1U1vTLAAAALAwMAAD2GzMzMjZmZBmZYZsZmFjmYYMzMMmtMAMAsB2YZmZmlZbmZ2aAAAAWAGsZgZMDzAAYmhZMGNA

# Saved Loadout: Raid - 12.0.5
# talents=CEEAzbn3egSOtoSwvPw1U1vTLAAAALAwAAAWmZmZMjZmZjBjZZsNzsMDDGzYmZYMbMAMghNwGLzYmlZbmZ2MAAAALAwmhxMmBAAMzwMGDDA
# Saved Loadout: Raider.IO Build
# talents=CEEAzbn3egSOtoSwvPw1U1vTLAAAALAwMAADWGzMzMjZmZBGDLjtZmFzYwwYmZYMbMAMAsB2YbmZmlZbmZ2MAAAALshBbGYGzAAAmZYGjhB
# Saved Loadout: M+ - 12.1
# talents=CEEAzbn3egSOtoSwvPw1U1vTLAAAALAwMAAD2GzMzMjZmZBmZYZsZmFDDGGzMDjZjBgBgNwGLzMzsMbzMzmBAAAYBYwmBmxMMDAgZGmxYYA
# Saved Loadout: M+ - 12.0.5
# talents=CEEAzbn3egSOtoSwvPw1U1vTLAAAALAwMAADWGzMzMjZmZBGDLjtZmFzYwwYmZYMbMAMAsB2YZmZmlZbmZ2MAAAALshBbGYGzAAAmZYGjhB

omnium_talents=136814:1/136818:1/136817:1/136819:1/136822:1

# Luminant Verdict's Unwavering Gaze (289)
head=,id=249961,enchant_id=7961,gem_id=240969,bonus_id=6652/13534/13440/13338/13575/12806
# Rotmire's Sporeheart (285)
neck=,id=268291,gem_id=240900,bonus_id=6652/13668/13334/13787
# Luminant Verdict's Providence Watch (289)
shoulder=,id=249959,enchant_id=8031,bonus_id=6652/13440/13340/13574/12806
# Potion-Stained Cloak (282)
back=,id=193712,bonus_id=13440/6652/13577/12699/12804
# Luminant Verdict's Divine Warplate (289)
chest=,id=249964,enchant_id=8013,bonus_id=6652/13440/13336/13575/12806
# Red Linen Shirt (1)
shirt=,id=2575
# Light's March Bracers (276)
wrist=,id=249326,bonus_id=6652/12667/13577/13334/12798
# Luminant Verdict's Gauntlets (276)
hands=,id=249962,bonus_id=6652/13337/13574/12798
# Riphook Defender (289)
waist=,id=251086,bonus_id=13440/6652/12667/13577/12699/12806
# Luminant Verdict's Greaves (289)
legs=,id=249960,enchant_id=7937,bonus_id=13339/13440/6652/13575/12806
# Greaves of the Unformed (276)
feet=,id=249381,enchant_id=7962,bonus_id=6652/13577/13334/12798
# Bond of Light (276)
finger1=,id=249369,enchant_id=7969,gem_id=240900,bonus_id=41/13668/13334/12798
# Sporecaller's Blooming Loop (285)
finger2=,id=268290,enchant_id=7969,gem_id=240900,bonus_id=6652/13668/13334/13787
# Gaze of the Alnseer (285)
trinket1=,id=249343,bonus_id=6652/13334/13653
# Sporelord's Mycelial Insignia (285)
trinket2=,id=268292,bonus_id=6652/13334/13787
# Magister's Mana Sword (295)
main_hand=,id=237843,enchant_id=8039,bonus_id=12214/13655/12497/12066/12693/8960/8791/13622,content_tuning=3615,crafted_stats=40/36,crafting_quality=5
# Viryx's Indomitable Bulwark (285)
off_hand=,id=258049,bonus_id=13440/6652/12699/13653,content_tuning=1279

### Gear from Bags
#
# Luminant Verdict's Unwavering Gaze (250)
# head=,id=249961,bonus_id=6652/12667/12786/13338/13575/3135,redirected_base_stats=249656
#
# Luminant Verdict's Unwavering Gaze (276)
# head=,id=249961,bonus_id=13338/6652/12667/13575/12798
#
# Eternal Voidsong Chain (276)
# neck=,id=249368,bonus_id=6652/13668/13334/12798
#
# Pendant of Aching Grief (276)
# neck=,id=251096,bonus_id=13440/6652/13668/12699/12798,content_tuning=1279
#
# Amani Totemstring (246)
# neck=,id=265740,bonus_id=12785/6652/13668,content_tuning=4240
#
# Reshii Wraps (170)
# back=,id=235499,enchant_id=7409,gem_id=238045,bonus_id=12401/9893/12258,content_tuning=3008
#
# Shroud of the Soulhunter (276)
# back=,id=251161,bonus_id=13440/6652/13577/12699/12798,content_tuning=1279
#
# Burnt Watha'nan Breastplate (198)
# chest=,id=248020,bonus_id=13573/13613/13615/6652,drop_level=89,content_tuning=3321
#
# Putrid Tender's Battleplate (285)
# chest=,id=268285,bonus_id=6652/13577/13334/13787
#
# Tabard of Summer Flames (1)
# tabard=,id=35280,content_tuning=394
#
# Rampant Briarcuffs (259)
# wrist=,id=249660,bonus_id=12793/6652/12667/13577,content_tuning=6015
#
# Unraveling Cloth Handwraps (68)
# hands=,id=154790,bonus_id=6656,drop_level=90,content_tuning=464
#
# Luminant Verdict's Gauntlets (259)
# hands=,id=249962,bonus_id=6652/13439/13337/13574/12789
#
# Hara'ti Defender's Greatbelt (246)
# waist=,id=263269,bonus_id=13577/12785/12667,content_tuning=4240
#
# Legguards of the Awakening Brood (56)
# legs=,id=159375,bonus_id=9024/6652,content_tuning=502
#
# Rampant Bramblegreaves (250)
# legs=,id=249657,bonus_id=12786/6652/13577,content_tuning=6015
#
# Sand-Shined Snakeskin Sandals (56)
# feet=,id=159327,bonus_id=9024/6652,content_tuning=502
#
# Rampant Thistlestompers (250)
# feet=,id=249654,bonus_id=12786/6652/13577,content_tuning=6015
#
# Cyrce's Circlet (103)
# finger1=,id=228411,enchant_id=7340,gem_id=228638/228639/228640,bonus_id=12028/1511,content_tuning=3004
#
# Charged Sandstone Band (56)
# finger1=,id=158366,bonus_id=9024/6652/8812,content_tuning=502
#
# Occlusion of Void (250)
# finger1=,id=251217,enchant_id=7968,bonus_id=13439/41/13668/12699/12786
#
# Platinum Star Band (276)
# finger1=,id=193708,enchant_id=7969,gem_id=240900,bonus_id=13440/6652/13668/12699/12798,content_tuning=1279
#
# Glorious Crusader's Keepsake (250)
# trinket1=,id=251792,bonus_id=12786/6652,content_tuning=6015
#
# Refueling Orb (272)
# trinket1=,id=250246,bonus_id=12801/13440/6652/12699
#
# Nevermelting Ice Crystal (272)
# trinket1=,id=50259,bonus_id=12801/13440/6652/12699
#
# Tiny Electromental in a Jar (56)
# trinket1=,id=158374,bonus_id=9024/6652,content_tuning=502
#
# Crucible of Erratic Energies (263)
# trinket1=,id=264507,bonus_id=12790,content_tuning=4240
#
# Algeth'ar Puzzle Box (276)
# trinket1=,id=193701,bonus_id=13440/6652/12699/12798,content_tuning=1279
#
# Emberwing Feather (246)
# trinket1=,id=250144,bonus_id=12785/13439/6652/12699
#
# Litany of Lightblind Wrath (266)
# trinket1=,id=249808,bonus_id=6652/13334/12795
#
# Nevermelting Ice Crystal (246)
# trinket1=,id=50259,bonus_id=12785/13439/6652/12699
#
# Refueling Orb (246)
# trinket1=,id=250246,bonus_id=12785/13439/6652/12699
#
# Radiant Sunstone (272)
# trinket1=,id=252411,bonus_id=12801/13440/6652/12699
#
# Heart of Wind (298)
# trinket1=,id=250256,bonus_id=13440/6652/12699/13654
#
# Vessel of Tortured Souls (272)
# trinket1=,id=250258,bonus_id=12801/13440/6652/12699
#
# Mertei's Command Baton (256)
# main_hand=,id=275218,bonus_id=12788/8902,content_tuning=7331
#
# Root Sculptor's Verdaxe (263)
# main_hand=,id=249661,bonus_id=6652/12790,content_tuning=4898
#
# Mertei's Command Baton (259)
# main_hand=,id=275218,bonus_id=6652/13334/12793,content_tuning=7331
#
# Mertei's Command Baton (246)
# main_hand=,id=275218,bonus_id=12785/8902,content_tuning=7331
#
# Spellboon Saber (266)
# main_hand=,id=193710,bonus_id=12795/13440/6652/12701,content_tuning=1279
#
# Excavating Cudgel (246)
# main_hand=,id=251083,bonus_id=12785/13439/6652/12701
#
# Mertei's Command Baton (269)
# main_hand=,id=275218,bonus_id=6652/13334/12796,content_tuning=7331
#
# Garfrost's Two-Ton Hammer (263)
# main_hand=,id=49802,bonus_id=6652/12701/11215/12790,content_tuning=1279
#
# Everforged Defender (144)
# off_hand=,id=222432,bonus_id=10421/9633/8902/9627/8793/12050/12052/11109/8960,content_tuning=2734,crafted_stats=36/49,crafting_quality=5

### Additional Character Info
#
# catalyst_currencies=3269:8/3378:8/2813:8/3116:8
#
# upgrade_currencies=c:3442:10/c:3443:10/c:1813:2240/c:3444:10/i:210233:9/i:268552:3/i:224072:5/i:204276:3/i:232875:14/i:224069:1/i:230936:1/i:231769:1/i:211296:1
#
# slot_high_watermarks=0:289:302/1:285:305/2:289:289/3:289:289/4:289:302/5:289:292/6:276:295/7:276:289/8:276:292/9:276:289/10:285:298/11:282:295/12:263:289/13:295:298/14:263:269/15:214:214/16:285:298
#
# upgrade_achievements=40107/40115/40118/40942/40943/40944/40945/41886/41887/41888/41892/42767/42768/42769/42770/61809
#
# bonus_roll_currencies=3418:0/3511:0

# Checksum: c37dd631
```