### PR TITLE
Fix crafted item and embellishment handling

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -10,10 +10,11 @@ import {render} from '@testing-library/react';
 const middlewares = []
 const mockStore = configureStore(middlewares)
 
-jest.mock('General/Modules/TopGear/Engine/TopGearEngineShared', () => {
+// Worker construction uses import.meta.url, which only the webpack build can parse. Stub the factory so importing
+// App doesn't drag it in. The rest of TopGearEngineShared is plain functions and loads fine.
+jest.mock('General/Modules/TopGear/Engine/TopGearWorkerFactory', () => {
   return {
-    createFetcherWorker: jest.fn(),
-    createLoaderWorker: jest.fn(),
+    createTopGearWorker: jest.fn(),
   };
 });
 

--- a/src/Databases/EmbellishmentDB.ts
+++ b/src/Databases/EmbellishmentDB.ts
@@ -1,10 +1,29 @@
+// Every armor slot an applicable embellishment (a lining, banding, patch etc) can be attached to.
+// Jewelry and weapons are handled separately since they take different reagents.
+export const EMBELLISHMENT_ARMOR_SLOTS = ["Head", "Shoulder", "Back", "Chest", "Wrist", "Hands", "Waist", "Legs", "Feet"];
+export const EMBELLISHMENT_WEAPON_SLOTS = ["1H Weapon", "2H Weapon", "Warglaive Weapon", "Offhand", "Holdable"];
+export const EMBELLISHMENT_JEWELRY_SLOTS = ["Neck", "Finger"];
+
 type embellishmentData = {
   id: number;
   icon: string; // Shown in the Embellishment Chart
-  armorType: 0 | 1 | 2 | 3 | 4; // Cloth, Leather etc.
+  armorType: 0 | 1 | 2 | 3 | 4; // 0 = any, 1 Cloth, 2 Leather, 3 Mail, 4 Plate.
   name: string;
   warningFlag?: boolean; // True if we want to display a red symbol on the chart.
   pieces?: 1 | 2; // Number of pieces required for the effect. Always 1 or 2.
+
+  // "applicable" embellishments are reagents the player chooses to add to a crafted item, so they need to show up
+  // in the Add Item dropdown against every slot they're legal on. Everything else is baked into a specific crafted
+  // item (or item family) and arrives with the item itself, so it must NOT be offered as a choice.
+  applicable?: boolean;
+  slots?: string[]; // Slots this embellishment is legal on. Only meaningful when applicable is true.
+  setItems?: number[]; // For baked-in embellishments: the item IDs that carry it. Any `pieces` of these trigger it.
+
+  // Set when we know the embellishment exists but don't have a formula for it yet in EmbellishmentData.
+  // Those score as zero, so we must not offer them as a choice - picking one would silently do nothing.
+  // Delete the flag as soon as the formula lands.
+  unmodelled?: boolean;
+
   effect: {
     type: "embellishment";
     name: string;
@@ -17,6 +36,8 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_profession_blacksmithing_weightstone_green",
     armorType: 0, // Works on Weapons
     name: "Hunter's Ritual Stone",
+    applicable: true,
+    slots: EMBELLISHMENT_WEAPON_SLOTS,
     warningFlag: true,
     effect: {
       type: "embellishment",
@@ -28,6 +49,8 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_knife_1h_ulatek_d_01",
     armorType: 0, // Works on Armor, leatherworking craft.
     name: "Adorned Fang",
+    applicable: true,
+    slots: EMBELLISHMENT_ARMOR_SLOTS,
     effect: {
       type: "embellishment",
       name: "Adorned Fang",
@@ -38,6 +61,7 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_profession_jewelcrafting_ring1_gold",
     armorType: 0, // Ring
     name: "Signet of Azerothian Blessings",
+    setItems: [241140],
     effect: {
       type: "embellishment",
       name: "Signet of Azerothian Blessings",
@@ -46,8 +70,9 @@ export const embellishmentDB: embellishmentData[] = [
     {
     id: 241139,
     icon: "inv_12_profession_jewelcrafting_necklace1_gold",
-    armorType: 0, // Ring
+    armorType: 0, // Neck
     name: "Thalassian Phoenix Torque",
+    setItems: [241139],
     effect: {
       type: "embellishment",
       name: "Thalassian Phoenix Torque",
@@ -58,6 +83,7 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_profession_jewelcrafting_ring3_silver",
     armorType: 0, // Ring
     name: "Loa Worshiper's Band",
+    setItems: [251513],
     warningFlag: true,
     effect: {
       type: "embellishment",
@@ -67,8 +93,9 @@ export const embellishmentDB: embellishmentData[] = [
     {
     id: 251073,
     icon: "inv_12_profession_jewelcrafting_necklace3_silver",
-    armorType: 0, // Ring
+    armorType: 0, // Neck
     name: "Voidstone Shielding Array",
+    setItems: [251073],
     effect: {
       type: "embellishment",
       name: "Voidstone Shielding Array",
@@ -79,6 +106,8 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_profession_inscriptions_darkmoonsigil_hunt",
     armorType: 0, // Weapon Reagent, DPS only
     name: "Darkmoon Sigil: Blood",
+    applicable: true,
+    slots: EMBELLISHMENT_WEAPON_SLOTS,
     effect: {
       type: "embellishment",
       name: "Darkmoon Sigil: Blood",
@@ -89,6 +118,8 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_profession_inscriptions_darkmoonsigil_bloom",
     armorType: 0, // Weapon Reagent, Based on creature type??
     name: "Darkmoon Sigil: Hunt",
+    applicable: true,
+    slots: EMBELLISHMENT_WEAPON_SLOTS,
     effect: {
       type: "embellishment",
       name: "Darkmoon Sigil: Hunt",
@@ -99,6 +130,8 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_profession_inscriptions_darkmoonsigil_void",
     armorType: 0, // Weapon Reagent, DPS only.
     name: "Darkmoon Sigil: Void",
+    applicable: true,
+    slots: EMBELLISHMENT_WEAPON_SLOTS,
     effect: {
       type: "embellishment",
       name: "Darkmoon Sigil: Void",
@@ -109,6 +142,8 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_jewelry_necklace_139",
     armorType: 0, // Vers
     name: "Blessed Pango Charm",
+    applicable: true,
+    slots: EMBELLISHMENT_ARMOR_SLOTS,
     effect: {
       type: "embellishment",
       name: "Blessed Pango Charm",
@@ -119,6 +154,8 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_profession_leatherworking_armor_banding_green",
     armorType: 0, // Healing
     name: "Primal Spore Binding",
+    applicable: true,
+    slots: EMBELLISHMENT_ARMOR_SLOTS,
     effect: {
       type: "embellishment",
       name: "Primal Spore Binding",
@@ -129,6 +166,9 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_profession_leatherworking_armor_banding_brown",
     armorType: 0, // Healing
     name: "Devouring Banding",
+    applicable: true,
+    slots: EMBELLISHMENT_ARMOR_SLOTS,
+    unmodelled: true, // No formula in EmbellishmentData yet.
     effect: {
       type: "embellishment",
       name: "Devouring Banding",
@@ -139,6 +179,8 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_tailoring_rare_cloth_violet_rare-cloth",
     armorType: 0, // Primary stat for you + a friend
     name: "Arcanoweave Lining",
+    applicable: true,
+    slots: EMBELLISHMENT_ARMOR_SLOTS,
     effect: {
       type: "embellishment",
       name: "Arcanoweave Lining",
@@ -149,6 +191,8 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_12_tailoring_rare_cloth_orange-_rare-cloth",
     armorType: 0, // Healing and damage from periodics can increase int, stacking to 10.
     name: "Sunfire Silk Lining",
+    applicable: true,
+    slots: EMBELLISHMENT_ARMOR_SLOTS,
     effect: {
       type: "embellishment",
       name: "Sunfire Silk Lining",
@@ -160,6 +204,7 @@ export const embellishmentDB: embellishmentData[] = [
     armorType: 1, // Crit above 80% health, cloth, set
     pieces: 2,
     name: "Arcanoweave Trappings (Set)",
+    setItems: [239660, 239661, 239662], // Arcanoweave Bracers / Cloak / Treads
     effect: {
       type: "embellishment",
       name: "Arcanoweave Trappings",
@@ -170,6 +215,7 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_belt_cloth_questbloodelf_b_01",
     armorType: 1, // Mastery proc
     name: "Arcanoweave Cord",
+    setItems: [239664],
     effect: {
       type: "embellishment",
       name: "Arcanoweave Cord",
@@ -181,6 +227,7 @@ export const embellishmentDB: embellishmentData[] = [
     armorType: 1, // Crit above 80% health, cloth, set
     pieces: 2,
     name: "Sunfire Silk Trappings (Set)",
+    setItems: [239657, 239658, 239659], // Sunfire Bracers / Cloak / Treads
     effect: {
       type: "embellishment",
       name: "Sunfire Silk Trappings",
@@ -192,6 +239,8 @@ export const embellishmentDB: embellishmentData[] = [
     armorType: 2, // Does random shit every 30s on a crit. Untested for healing crits.
     pieces: 2,
     name: "Murder Row Materials (Set)",
+    setItems: [244612, 244613, 244614], // Row Walker's Deflectors / Insurance / Swiftgrips
+    unmodelled: true, // No formula in EmbellishmentData yet.
     effect: {
       type: "embellishment",
       name: "Murder Row Materials",
@@ -202,6 +251,7 @@ export const embellishmentDB: embellishmentData[] = [
     icon: "inv_boot_leather_questbloodelf_b_01",
     armorType: 2, // Pops out orbs. Pick up orb = + highest secondary stat.
     name: "World Tree Rootwraps",
+    setItems: [244601],
     effect: {
       type: "embellishment",
       name: "World Tree Rootwraps",
@@ -210,8 +260,9 @@ export const embellishmentDB: embellishmentData[] = [
   {
     id: 244605,
     icon: "inv_bracer_mail_questbloodelf_b_01",
-    armorType: 3, // Stacking haste proc  
+    armorType: 3, // Stacking haste proc
     name: "Axe-Flingin' Bands",
+    setItems: [244605],
     effect: {
       type: "embellishment",
       name: "Axe-Flingin' Bands",
@@ -223,6 +274,7 @@ export const embellishmentDB: embellishmentData[] = [
     armorType: 3, // Random secondary proc
     pieces: 2,
     name: "Root Warden's Regalia (Set)",
+    setItems: [244609, 244610, 244611], // World Tender's Trunkplate / Rootslippers / Barkclasp
     effect: {
       type: "embellishment",
       name: "Root Warden's Regalia",
@@ -415,6 +467,41 @@ export const embellishmentDB: embellishmentData[] = [
     },
   },*/
 ];
+
+/* ---------------------------------------------------------------------------------------------- */
+/*                                            Lookups                                             */
+/* ---------------------------------------------------------------------------------------------- */
+// These are the single source of truth for "which embellishments exist and where can they go".
+// Both the Add Item dropdown (getItemEffectOptions) and the SimC importer read from here so that the
+// two entry points can't drift apart from each other or from the formulas in EmbellishmentData.
+
+// Every embellishment the player can choose to apply to a crafted item in the given slot.
+// Anything we don't have a formula for is left out - it would score as a flat zero and look like a bad choice
+// rather than an unimplemented one.
+export const getApplicableEmbellishments = (slot: string): embellishmentData[] => {
+  if (!slot) return [];
+  return embellishmentDB.filter((embel) => embel.applicable === true && !embel.unmodelled && (embel.slots || []).includes(slot));
+};
+
+// Look an embellishment up by its effect name. This is the name the formulas in EmbellishmentData key off.
+export const getEmbellishmentByEffectName = (effectName: string): embellishmentData | undefined => {
+  if (!effectName) return undefined;
+  const trimmed = effectName.trim();
+  return embellishmentDB.find((embel) => embel.effect.name.trim() === trimmed || embel.name.trim() === trimmed);
+};
+
+// Returns the embellishment carried by a given crafted item ID, if any. Used to attach baked-in effects
+// (Axe-Flingin' Bands, the World Tender's set and so on) without having to duplicate them into ItemDB.
+export const getEmbellishmentForItem = (itemID: number): embellishmentData | undefined => {
+  if (!itemID) return undefined;
+  return embellishmentDB.find((embel) => (embel.setItems || []).includes(itemID));
+};
+
+// The set of item IDs that carry a baked-in embellishment.
+export const embellishmentItemIDs: number[] = embellishmentDB.reduce(
+  (acc: number[], embel) => acc.concat(embel.setItems || []),
+  [],
+);
 
   /*
   {

--- a/src/General/Engine/CraftedEmbellishments.test.js
+++ b/src/General/Engine/CraftedEmbellishments.test.js
@@ -1,0 +1,202 @@
+import { getItemEffectOptions, hasUnallocatedStats, getItemAllocations } from "./ItemUtilities";
+import { getApplicableEmbellishments, getEmbellishmentByEffectName, getEmbellishmentForItem, embellishmentDB } from "Databases/EmbellishmentDB";
+import { embellishmentData } from "Retail/Engine/EffectFormulas/Generic/Embellishments/EmbellishmentData";
+import Item from "General/Items/Item";
+import ItemSet from "General/Modules/TopGear/ItemSet";
+import Player from "General/Modules/Player/Player";
+import { getEffectValue } from "Retail/Engine/EffectFormulas/EffectEngine";
+
+const effectSettings = {
+  calculateEmbellishments: { value: true, options: [true, false], category: "embellishments", type: "selector" },
+  darkmoonHuntStat: { value: "Mastery", options: ["Mastery", "Versatility", "Crit", "Haste"], category: "embellishments", type: "selector" },
+};
+
+/*
+  Crafted gear and embellishments for Preservation Evoker (mail).
+
+  These cover the paths that previously dropped embellishments silently: the Add Item dropdown, the crafted stat
+  picker, embellishments baked into specific crafted items, and multi-piece embellishment sets.
+*/
+
+// Mail crafted gear an Evoker can actually wear.
+const WORLD_TENDERS_CHEST = 244609; // Root Warden's Regalia (Set) carrier
+const WORLD_TENDERS_FEET = 244610;
+const WORLD_TENDERS_WAIST = 244611;
+const AXE_FLINGIN_BANDS = 244605; // 1 piece mail embellishment
+const FARSTRIDERS_CHEST = 244578; // plain crafted mail, takes an applied embellishment
+const MAGISTERS_RITUAL_KNIFE = 237838; // crafted intellect dagger
+const CONSECRATED_CLOAK = 271460; // newer crafted piece with fixed secondaries
+
+describe("Embellishment DB is consistent with the formulas that score it", () => {
+  const hasFormula = (embel) => embellishmentData.some((data) => data.name.trim() === embel.effect.name.trim());
+
+  test("every embellishment either has a formula or is flagged unmodelled", () => {
+    const silentlyBroken = embellishmentDB.filter((embel) => !hasFormula(embel) && !embel.unmodelled).map((embel) => embel.effect.name);
+
+    expect(silentlyBroken).toEqual([]);
+  });
+
+  test("nothing is flagged unmodelled once a formula exists for it", () => {
+    const staleFlags = embellishmentDB.filter((embel) => embel.unmodelled && hasFormula(embel)).map((embel) => embel.effect.name);
+
+    expect(staleFlags).toEqual([]);
+  });
+
+  test("unmodelled embellishments are never offered as a choice", () => {
+    const unmodelled = embellishmentDB.filter((embel) => embel.unmodelled).map((embel) => embel.effect.name);
+    expect(unmodelled.length).toBeGreaterThan(0); // Guard against this test quietly becoming vacuous.
+
+    const offered = ["Chest", "Wrist", "Waist", "Feet", "Head", "Legs", "Hands", "Back", "Shoulder", "1H Weapon", "2H Weapon", "Offhand"]
+      .reduce((acc, slot) => acc.concat(getApplicableEmbellishments(slot).map((embel) => embel.effect.name)), []);
+
+    unmodelled.forEach((name) => expect(offered).not.toContain(name));
+  });
+
+  test("lookup by effect name tolerates stray whitespace in either DB", () => {
+    expect(getEmbellishmentByEffectName("Sunfire Silk Lining")).toBeTruthy();
+    expect(getEmbellishmentByEffectName("  Sunfire Silk Lining  ")).toBeTruthy();
+    expect(getEmbellishmentByEffectName("Not A Real Embellishment")).toBeUndefined();
+  });
+});
+
+describe("Add Item offers the embellishments that exist rather than a hardcoded subset", () => {
+  test("a crafted mail chest offers every applicable armor embellishment", () => {
+    const options = getItemEffectOptions(FARSTRIDERS_CHEST).map((opt) => opt.effectName);
+
+    // These four were the entire hardcoded list before, and must still be present.
+    expect(options).toEqual(expect.arrayContaining(["Arcanoweave Lining", "Primal Spore Binding", "Blessed Pango Charm", "Adorned Fang"]));
+    // This was in the DB with a working formula but was never offered.
+    expect(options).toContain("Sunfire Silk Lining");
+  });
+
+  test("a crafted weapon offers the weapon reagents, including Darkmoon Sigil: Blood", () => {
+    const options = getItemEffectOptions(MAGISTERS_RITUAL_KNIFE).map((opt) => opt.effectName);
+
+    expect(options).toEqual(expect.arrayContaining(["Darkmoon Sigil: Hunt", "Darkmoon Sigil: Void", "Hunter's Ritual Stone"]));
+    expect(options).toContain("Darkmoon Sigil: Blood");
+  });
+
+  test("armor embellishments are not offered on weapons and weapon reagents are not offered on armor", () => {
+    const weaponOptions = getItemEffectOptions(MAGISTERS_RITUAL_KNIFE).map((opt) => opt.effectName);
+    const armorOptions = getItemEffectOptions(FARSTRIDERS_CHEST).map((opt) => opt.effectName);
+
+    expect(weaponOptions).not.toContain("Arcanoweave Lining");
+    expect(armorOptions).not.toContain("Darkmoon Sigil: Hunt");
+  });
+
+  test("embellishments baked into a specific item are never offered as a choice", () => {
+    const allOffered = getApplicableEmbellishments("Chest").concat(getApplicableEmbellishments("Wrist")).map((embel) => embel.effect.name);
+
+    expect(allOffered).not.toContain("Axe-Flingin' Bands");
+    expect(allOffered).not.toContain("Root Warden's Regalia");
+  });
+
+  test("non-crafted items offer nothing", () => {
+    expect(getItemEffectOptions(0)).toEqual([]);
+  });
+});
+
+describe("Crafted stat picker only appears when there is budget to assign", () => {
+  test("older crafted gear with unallocated stats can have its secondaries chosen", () => {
+    expect(hasUnallocatedStats(FARSTRIDERS_CHEST)).toBe(true);
+
+    const haste = getItemAllocations(FARSTRIDERS_CHEST, ["haste", "mastery"]);
+    const crit = getItemAllocations(FARSTRIDERS_CHEST, ["crit", "versatility"]);
+
+    expect(haste.haste).toBeGreaterThan(0);
+    expect(crit.crit).toBeGreaterThan(0);
+    expect(haste.crit || 0).toEqual(0);
+  });
+
+  test("crafted gear with fixed secondaries reports no assignable budget", () => {
+    // This item ships with its secondaries already baked in, so offering a stat picker would do nothing.
+    expect(hasUnallocatedStats(CONSECRATED_CLOAK)).toBe(false);
+
+    const asHaste = getItemAllocations(CONSECRATED_CLOAK, ["haste", "mastery"]);
+    const asCrit = getItemAllocations(CONSECRATED_CLOAK, ["crit", "versatility"]);
+    expect(asHaste).toEqual(asCrit);
+  });
+});
+
+describe("Embellishments baked into crafted items attach automatically", () => {
+  test("EmbellishmentDB knows which items carry which embellishment", () => {
+    expect(getEmbellishmentForItem(AXE_FLINGIN_BANDS).effect.name).toEqual("Axe-Flingin' Bands");
+    expect(getEmbellishmentForItem(WORLD_TENDERS_CHEST).effect.name).toEqual("Root Warden's Regalia");
+    expect(getEmbellishmentForItem(FARSTRIDERS_CHEST)).toBeUndefined();
+  });
+
+  test("a mail set piece with no effect in ItemDB still builds with its embellishment", () => {
+    // ItemDB has no effect block on the World Tender's pieces, which meant they simmed as plain stat sticks.
+    const item = new Item(WORLD_TENDERS_CHEST, "World Tender's Trunkplate", "Chest", 0, "", 0, 330, "");
+
+    expect(item.effect).toBeTruthy();
+    expect(item.effect.name).toEqual("Root Warden's Regalia");
+    expect(item.effect.type).toEqual("embellishment");
+  });
+
+  test("an item that already has an effect in ItemDB keeps it", () => {
+    const item = new Item(AXE_FLINGIN_BANDS, "Axe-Flingin' Bands", "Wrist", 0, "", 0, 330, "");
+    expect(item.effect.name).toEqual("Axe-Flingin' Bands");
+  });
+});
+
+describe("Multi-piece embellishment sets are counted once, and only when complete", () => {
+  const buildSet = (itemIDs) => {
+    const items = itemIDs.map((entry) => new Item(entry.id, "", entry.slot, 0, "", 0, 330, ""));
+    return new ItemSet(1, items, 0, "Preservation Evoker").compileStats("Retail", {});
+  };
+
+  const countEffect = (set, name) => set.effectList.filter((effect) => effect.name === name).length;
+
+  test("one piece of a two piece set grants nothing", () => {
+    const set = buildSet([{ id: WORLD_TENDERS_CHEST, slot: "Chest" }]);
+    expect(countEffect(set, "Root Warden's Regalia")).toEqual(0);
+  });
+
+  test("two pieces grant the set bonus exactly once", () => {
+    const set = buildSet([
+      { id: WORLD_TENDERS_CHEST, slot: "Chest" },
+      { id: WORLD_TENDERS_FEET, slot: "Feet" },
+    ]);
+    expect(countEffect(set, "Root Warden's Regalia")).toEqual(1);
+  });
+
+  test("three pieces still only grant it once", () => {
+    const set = buildSet([
+      { id: WORLD_TENDERS_CHEST, slot: "Chest" },
+      { id: WORLD_TENDERS_FEET, slot: "Feet" },
+      { id: WORLD_TENDERS_WAIST, slot: "Waist" },
+    ]);
+    expect(countEffect(set, "Root Warden's Regalia")).toEqual(1);
+  });
+
+  test("each worn set piece consumes an embellishment slot", () => {
+    const set = buildSet([
+      { id: WORLD_TENDERS_CHEST, slot: "Chest" },
+      { id: WORLD_TENDERS_FEET, slot: "Feet" },
+    ]);
+    expect(set.uniques["embellishment"]).toEqual(2);
+  });
+
+  test("a single piece embellishment is unaffected", () => {
+    const set = buildSet([{ id: AXE_FLINGIN_BANDS, slot: "Wrist" }]);
+    expect(countEffect(set, "Axe-Flingin' Bands")).toEqual(1);
+  });
+
+  test("the resolved set bonus actually scores, rather than resolving to an empty effect", () => {
+    // Attaching the effect is only half the job - it also has to route through EffectEngine to a formula that
+    // returns stats. A name mismatch anywhere in that chain comes back as {} and silently scores zero.
+    const set = buildSet([
+      { id: WORLD_TENDERS_CHEST, slot: "Chest" },
+      { id: WORLD_TENDERS_FEET, slot: "Feet" },
+    ]);
+    const effect = set.effectList.find((entry) => entry.name === "Root Warden's Regalia");
+
+    const player = new Player("Tester", "Preservation Evoker", 1, "US", "Stonemaul", "Dracthyr", "default", "Retail");
+    const bonusStats = getEffectValue(effect, player, player.getActiveModel("Raid"), "Raid", effect.level, effectSettings, "Retail", {}, {});
+
+    expect(Object.keys(bonusStats).length).toBeGreaterThan(0);
+    const total = Object.values(bonusStats).reduce((sum, value) => sum + (value || 0), 0);
+    expect(total).toBeGreaterThan(0);
+  });
+});

--- a/src/General/Engine/EmbellishmentCap.test.js
+++ b/src/General/Engine/EmbellishmentCap.test.js
@@ -1,0 +1,105 @@
+import Item from "General/Items/Item";
+import ItemSet from "General/Modules/TopGear/ItemSet";
+import { isEmbellished, getForcedEmbellishmentCount, MAX_EMBELLISHMENTS } from "General/Engine/ItemUtilities";
+
+/*
+  Only two embellishments can be worn at once, and ItemSet.verifySet throws out any set that exceeds it. That's
+  correct, but it used to happen invisibly: a player already wearing two embellishments who added a third
+  embellished item (typically a crafted weapon) had it silently dropped from every set. If the new item was their
+  only option in its slot, every set failed verification and Top Gear returned an empty report with no explanation.
+*/
+
+const CRAFTED_MAIL_CHEST = 244578;
+const CRAFTED_2H = 245770; // Aln'hara Cane
+const CRAFTED_OFFHAND = 245769; // Aln'hara Lantern
+const PLAIN_2H = 268205; // Venomancer's Winged Channeler, raid drop with no embellishment
+
+const embellished = (id, slot, level = 330) => {
+  const item = new Item(id, "", slot, 0, "", 0, level, "");
+  item.effect = { type: "embellishment", name: "Arcanoweave Lining", level: level };
+  item.uniqueEquip = "embellishment"; // what ItemBar sets when an embellishment is chosen
+  return item;
+};
+
+const plain = (id, slot, level = 330) => new Item(id, "", slot, 0, "", 0, level, "");
+
+describe("isEmbellished", () => {
+  test("detects an embellishment applied through the item bar", () => {
+    expect(isEmbellished(embellished(CRAFTED_MAIL_CHEST, "Chest"))).toBe(true);
+  });
+
+  test("detects an embellishment baked into the item", () => {
+    // Axe-Flingin' Bands carries its embellishment inherently rather than having one applied.
+    expect(isEmbellished(new Item(244605, "", "Wrist", 0, "", 0, 330, ""))).toBe(true);
+  });
+
+  test("a plain item is not embellished", () => {
+    expect(isEmbellished(plain(PLAIN_2H, "2H Weapon"))).toBe(false);
+    expect(isEmbellished(null)).toBe(false);
+  });
+});
+
+describe("A set over the embellishment cap is rejected", () => {
+  const buildSet = (items) => new ItemSet(1, items, 0, "Preservation Evoker").compileStats("Retail", {});
+
+  test("two embellishments is fine", () => {
+    const set = buildSet([embellished(CRAFTED_MAIL_CHEST, "Chest"), embellished(244584, "Wrist")]);
+
+    expect(set.uniques["embellishment"]).toEqual(MAX_EMBELLISHMENTS);
+    expect(set.verifySet({})).toBe(true);
+  });
+
+  test("three embellishments is rejected, which is what hides the third item", () => {
+    const set = buildSet([
+      embellished(CRAFTED_MAIL_CHEST, "Chest"),
+      embellished(244584, "Wrist"),
+      embellished(CRAFTED_2H, "2H Weapon", 331),
+    ]);
+
+    expect(set.uniques["embellishment"]).toEqual(3);
+    expect(set.verifySet({})).toBe(false);
+  });
+});
+
+describe("getForcedEmbellishmentCount spots the unwinnable case up front", () => {
+  test("counts slots where every selected option is embellished", () => {
+    const items = [
+      embellished(CRAFTED_MAIL_CHEST, "Chest"), // only chest, embellished -> forced
+      embellished(244584, "Wrist"), // only wrist, embellished -> forced
+      embellished(CRAFTED_2H, "2H Weapon", 331), // only weapon, embellished -> forced
+    ];
+
+    expect(getForcedEmbellishmentCount(items)).toEqual(3);
+    expect(getForcedEmbellishmentCount(items)).toBeGreaterThan(MAX_EMBELLISHMENTS);
+  });
+
+  test("a slot with a non-embellished alternative is not forced", () => {
+    const items = [
+      embellished(CRAFTED_MAIL_CHEST, "Chest"),
+      embellished(244584, "Wrist"),
+      embellished(CRAFTED_2H, "2H Weapon", 331),
+      plain(PLAIN_2H, "2H Weapon"), // gives the weapon slot a way out
+    ];
+
+    expect(getForcedEmbellishmentCount(items)).toEqual(2);
+    expect(getForcedEmbellishmentCount(items)).toBeLessThanOrEqual(MAX_EMBELLISHMENTS);
+  });
+
+  test("weapons and offhands count as a single slot, since a set only takes one combination", () => {
+    const items = [
+      embellished(CRAFTED_2H, "2H Weapon", 331),
+      embellished(CRAFTED_OFFHAND, "Offhand", 331),
+    ];
+
+    // Two embellished weapon-side items are one forced slot, not two.
+    expect(getForcedEmbellishmentCount(items)).toEqual(1);
+  });
+
+  test("a fully plain set forces nothing", () => {
+    expect(getForcedEmbellishmentCount([plain(PLAIN_2H, "2H Weapon"), plain(244578, "Chest")])).toEqual(0);
+  });
+
+  test("an empty selection forces nothing", () => {
+    expect(getForcedEmbellishmentCount([])).toEqual(0);
+  });
+});

--- a/src/General/Engine/ItemUtilities.ts
+++ b/src/General/Engine/ItemUtilities.ts
@@ -1,5 +1,5 @@
 import itemDB from "Databases/ItemDB.json";
-import { embellishmentDB } from "../../Databases/EmbellishmentDB";
+import { embellishmentDB, getApplicableEmbellishments, getEmbellishmentForItem } from "../../Databases/EmbellishmentDB";
 import { getOnyxAnnuletEffect } from "Retail/Engine/EffectFormulas/Generic/PatchEffectItems/OnyxAnnuletData";
 import { getCircletEffect } from "Retail/Engine/EffectFormulas/Generic/PatchEffectItems/CyrcesCircletData";
 import classicItemDB from "Databases/ClassicItemDB.json";
@@ -383,28 +383,23 @@ export function getItemLevelBoost(bossID: number, difficulty: number) {
 }
 
 // Sometimes items have an optional effect that can be added to them. Embellishments for example, or different variations (Changeling / Circlet).
+// The embellishment list is generated from EmbellishmentDB rather than hardcoded here. Hardcoding it meant every new patch
+// silently shipped a dropdown that was missing embellishments we already had working formulas for.
 export const getItemEffectOptions = (itemID: number, gameType: gameTypes = "Retail"): { type: string; label: string; effectName: string }[] => {
   const options: { type: string; label: string; effectName: string }[] = []; // type: "embellishment", label: "Add Embellishment: Writhing Armor Banding", effectName: "Writhing Armor Banding"
   const item = getItem(itemID);
+  if (!item) return options;
+
   const isEngineering = getItemProp(itemID, "engineering");
 
   if (getItemProp(item.id, "crafted")) {
     // Crafted item effects are limited to Embellishments currently.
-    if (item.slot.includes("Weapon") || item.slot === "Offhand") {
-      // Sigil embellishments are limited to weapon and offhand slots. Does NOT include Shields.
-      options.push({type: "embellishment", label: "Darkmoon Sigil: Hunt", effectName: "Darkmoon Sigil: Hunt"})
-      options.push({type: "embellishment", label: "Darkmoon Sigil: Void", effectName: "Darkmoon Sigil: Void"})
-      options.push({type: "embellishment", label: "Hunter's Ritual Stone", effectName: "Hunter's Ritual Stone"})
-      //options.push({type: "embellishment", label: "Darkmoon Sigil: Symbiosis", effectName: "Darkmoon Sigil: Symbiosis"})
+    // Engineering pieces take their own tinkers and can't hold a normal embellishment.
+    if (!isEngineering) {
+      getApplicableEmbellishments(item.slot).forEach((embel) => {
+        options.push({ type: "embellishment", label: embel.name, effectName: embel.effect.name });
+      });
     }
-    if (item.slot !== "Finger" && item.slot !== "Neck" && !item.slot.includes("Weapon") && !isEngineering) {
-      // Linings & Armor Banding are limited to non-weapon, non-jewelry slots.
-      options.push({type: "embellishment", label: "Arcanoweave Lining", effectName: "Arcanoweave Lining"})
-      options.push({type: "embellishment", label: "Primal Spore Binding", effectName: "Primal Spore Binding"})
-      options.push({type: "embellishment", label: "Blessed Pango Charm", effectName: "Blessed Pango Charm"})
-      options.push({type: "embellishment", label: "Adorned Fang", effectName: "Adorned Fang"})
-    }
-    
   }
   // Now, we can also add non-embellishment options here but we don't have any prominent ones yet so TODO.
 
@@ -667,6 +662,43 @@ export function checkDefaultSocket(id: number) {
 }
 
 // Returns item stat allocations. MUST be converted to stats before it's used in any scoring capacity.
+// The number of embellishments a character can wear at once. Exceeding it makes a set unwearable in game, so
+// Top Gear discards those sets entirely - which looks like the item you just added being ignored.
+export const MAX_EMBELLISHMENTS = 2;
+
+// True if wearing this item uses up one of the player's embellishment slots.
+export function isEmbellished(item: any) {
+  if (!item) return false;
+  return (typeof item.uniqueEquip === "string" && item.uniqueEquip.toLowerCase() === "embellishment") ||
+         (!!item.effect && item.effect.type === "embellishment");
+}
+
+// Counts the embellishments the player is forced to wear: slots where every selected item is embellished leave no
+// choice. If that forced total exceeds the cap then no wearable set exists at all and Top Gear will return nothing,
+// so we can tell the player up front instead of handing them an empty report.
+export function getForcedEmbellishmentCount(itemList: any[]) {
+  const bySlot: { [key: string]: { total: number; embellished: number } } = {};
+
+  itemList.forEach((item) => {
+    // Weapons are combined separately and a set only ever takes one combination, so count them as a single slot.
+    const slot = ["1H Weapon", "2H Weapon", "Offhand", "Holdable", "Shield"].includes(item.slot) ? "Weapon" : item.slot;
+    if (!bySlot[slot]) bySlot[slot] = { total: 0, embellished: 0 };
+    bySlot[slot].total += 1;
+    if (isEmbellished(item)) bySlot[slot].embellished += 1;
+  });
+
+  return Object.keys(bySlot).filter((slot) => bySlot[slot].total > 0 && bySlot[slot].total === bySlot[slot].embellished).length;
+}
+
+// Returns true if the item has stat budget for the player to assign. Generic crafted gear is all unallocated, so
+// this is almost always true - it's the fixed-embellished items (and a handful of older pieces) that arrive with
+// their secondaries already set, and offering a stat picker on those does nothing but mislead.
+export function hasUnallocatedStats(id: number, gameType: gameTypes = "Retail") {
+  const item = getItem(id, gameType);
+  if (!item || !item.stats) return false;
+  return "unallocated" in item.stats || "unallocated2" in item.stats;
+}
+
 export function getItemAllocations(id: number, missiveStats: any[] = [], gameType: gameTypes = "Retail") {
   const item = getItem(id, gameType);
 
@@ -738,6 +770,7 @@ export function buildNewWepCombos(player: Player, active: boolean = false, equip
   for (let i = 0; i < main_hands.length; i++) {
     // Some say j is the best variable for a nested loop, but are they right?
     let main_hand = main_hands[i];
+    let paired = false;
     for (let k = 0; k < off_hands.length; k++) {
       let off_hand = off_hands[k];
 
@@ -747,8 +780,14 @@ export function buildNewWepCombos(player: Player, active: boolean = false, equip
       } else {
         const combo = [main_hand, off_hand];
         combos.push(combo);
+        paired = true;
       }
     }
+
+    // A one hander that couldn't be paired with anything still has to be offered on its own. Dropping it used to
+    // make the weapon invisible to Top Gear, and if it was the player's only weapon there were no valid combos at
+    // all, which meant zero sets and an empty report rather than a result with an empty offhand slot.
+    if (!paired) combos.push([main_hand]);
   }
 
   for (let j = 0; j < two_handers.length; j++) {

--- a/src/General/Engine/WeaponCombos.test.js
+++ b/src/General/Engine/WeaponCombos.test.js
@@ -1,0 +1,109 @@
+import Player from "General/Modules/Player/Player";
+import Item from "General/Items/Item";
+import { buildNewWepCombos, getValidWeaponTypesBySpec, getItemProp } from "General/Engine/ItemUtilities";
+
+/*
+  Weapon combinations for Top Gear.
+
+  Top Gear doesn't take weapons from the per-slot item lists - they arrive as pre-built combos, and the set builder
+  loops `weapon < wepCombos.length`. That means a weapon missing from this list isn't just excluded from the
+  comparison: if it was the only weapon selected there are zero combos, the loop body never runs, and Top Gear
+  produces no sets at all. A one handed weapon used to be dropped whenever the player hadn't also selected an
+  offhand, so adding a single one hander returned an empty report.
+*/
+
+const ONE_HANDER = 271092; // Jan'thrazet, the Soul Fang - dagger, current raid
+const TWO_HANDER = 245770; // Aln'hara Cane - crafted staff
+const OFFHAND = 245769; // Aln'hara Lantern - crafted offhand
+
+const makePlayer = () => new Player("Tester", "Preservation Evoker", 1, "US", "Stonemaul", "Dracthyr", "default", "Retail");
+
+const withWeapons = (weapons) => {
+  const player = makePlayer();
+  weapons.forEach(([id, slot, level]) => player.activeItems.push(new Item(id, "", slot, 0, "", 0, level, "")));
+  player.activateAll();
+  return buildNewWepCombos(player, true);
+};
+
+const slotsOf = (combos) => combos.map((combo) => combo.map((item) => item.slot));
+
+describe("Preservation Evoker can use these weapons at all", () => {
+  test("the test weapons are the shapes this suite assumes", () => {
+    expect(getItemProp(ONE_HANDER, "slot")).toEqual("1H Weapon");
+    expect(getItemProp(TWO_HANDER, "slot")).toEqual("2H Weapon");
+    expect(getItemProp(OFFHAND, "slot")).toEqual("Offhand");
+  });
+
+  test("their subclasses are all usable by the spec", () => {
+    const usable = getValidWeaponTypesBySpec("Preservation Evoker");
+
+    expect(usable).toContain(getItemProp(ONE_HANDER, "itemSubClass")); // daggers
+    expect(usable).toContain(getItemProp(TWO_HANDER, "itemSubClass")); // staves
+  });
+});
+
+describe("Every selected weapon reaches Top Gear", () => {
+  test("a two hander on its own is offered", () => {
+    const combos = withWeapons([[TWO_HANDER, "2H Weapon", 331]]);
+
+    expect(combos.length).toEqual(1);
+    expect(slotsOf(combos)).toEqual([["2H Weapon"]]);
+  });
+
+  test("a one hander on its own is offered, with an empty offhand", () => {
+    const combos = withWeapons([[ONE_HANDER, "1H Weapon", 334]]);
+
+    // Regression: this used to be 0, which produced no sets and therefore a completely empty report.
+    expect(combos.length).toEqual(1);
+    expect(slotsOf(combos)).toEqual([["1H Weapon"]]);
+  });
+
+  test("a one hander pairs with an offhand when one is selected", () => {
+    const combos = withWeapons([
+      [ONE_HANDER, "1H Weapon", 334],
+      [OFFHAND, "Offhand", 331],
+    ]);
+
+    expect(combos.length).toEqual(1);
+    expect(slotsOf(combos)).toEqual([["1H Weapon", "Offhand"]]);
+  });
+
+  test("an unpaired one hander is not dropped just because a two hander exists", () => {
+    const combos = withWeapons([
+      [ONE_HANDER, "1H Weapon", 334],
+      [TWO_HANDER, "2H Weapon", 331],
+    ]);
+
+    // Regression: this used to return only the two hander, so the one hander was never compared.
+    expect(combos.length).toEqual(2);
+    expect(slotsOf(combos)).toEqual(expect.arrayContaining([["1H Weapon"], ["2H Weapon"]]));
+  });
+
+  test("a one hander is paired rather than offered bare when both are available", () => {
+    const combos = withWeapons([
+      [ONE_HANDER, "1H Weapon", 334],
+      [OFFHAND, "Offhand", 331],
+      [TWO_HANDER, "2H Weapon", 331],
+    ]);
+
+    expect(combos.length).toEqual(2);
+    expect(slotsOf(combos)).toEqual(expect.arrayContaining([["1H Weapon", "Offhand"], ["2H Weapon"]]));
+    // The bare fallback must not fire when a real pairing exists.
+    expect(slotsOf(combos)).not.toContainEqual(["1H Weapon"]);
+  });
+
+  test("every selected weapon appears somewhere in the combo list", () => {
+    const combos = withWeapons([
+      [ONE_HANDER, "1H Weapon", 334],
+      [TWO_HANDER, "2H Weapon", 331],
+      [OFFHAND, "Offhand", 331],
+    ]);
+    const ids = combos.reduce((acc, combo) => acc.concat(combo.map((item) => item.id)), []);
+
+    [ONE_HANDER, TWO_HANDER, OFFHAND].forEach((id) => expect(ids).toContain(id));
+  });
+
+  test("no weapons selected still means no combos", () => {
+    expect(withWeapons([]).length).toEqual(0);
+  });
+});

--- a/src/General/Items/GearImport/SimCEmbellishmentImport.test.js
+++ b/src/General/Items/GearImport/SimCEmbellishmentImport.test.js
@@ -1,0 +1,88 @@
+import Player from "General/Modules/Player/Player";
+import { processItem } from "General/Items/GearImport/SimCImportEngine";
+import { embellishmentDB } from "Databases/EmbellishmentDB";
+
+/*
+  The SimC importer used to check the incoming spell name against a hardcoded list of eight embellishments.
+  Anything outside that list was parsed and then silently discarded, so the item imported as a plain stat stick
+  and Top Gear scored it as one. These cover the embellishments an Evoker can realistically import.
+*/
+
+const player = new Player("Tester", "Preservation Evoker", 1, "US", "Stonemaul", "Dracthyr", "default", "Retail");
+const settings = {};
+
+// Bonus IDs that carry each embellishment's spell, taken from BonusIDs.ts.
+const EMBELLISHMENT_BONUS_IDS = {
+  "Adorned Fang": 13767,
+  "Sunfire Silk Lining": 12385,
+  "Arcanoweave Lining": 12384,
+  "Hunter's Ritual Stone": 13771,
+  "Blessed Pango Charm": 12686,
+  "Primal Spore Binding": 12687,
+  "Darkmoon Sigil: Hunt": 12693,
+  "Darkmoon Sigil: Void": 13640,
+  "Darkmoon Sigil: Blood": 12705,
+};
+
+// A crafted mail chest and a crafted dagger, both usable by a Preservation Evoker.
+const CRAFTED_MAIL_CHEST = 244578;
+const CRAFTED_DAGGER = 237838;
+
+const importItem = (itemID, slotName, bonusID) => {
+  const line = `${slotName}=,id=${itemID},bonus_id=12052/${bonusID},crafted_stats=36/49,crafting_quality=5`;
+  return processItem(line, player, "Raid", "", settings, false, false);
+};
+
+describe("SimC import keeps embellishments instead of dropping them", () => {
+  test("an embellishment that was already on the old allowlist still imports", () => {
+    const item = importItem(CRAFTED_MAIL_CHEST, "chest", EMBELLISHMENT_BONUS_IDS["Arcanoweave Lining"]);
+
+    expect(item).toBeTruthy();
+    expect(item.effect).toBeTruthy();
+    expect(item.effect.type).toEqual("embellishment");
+    expect(item.effect.name).toEqual("Arcanoweave Lining");
+  });
+
+  test("Adorned Fang imports - it was offered in the UI but dropped on import", () => {
+    const item = importItem(CRAFTED_MAIL_CHEST, "chest", EMBELLISHMENT_BONUS_IDS["Adorned Fang"]);
+
+    expect(item.effect).toBeTruthy();
+    expect(item.effect.name).toEqual("Adorned Fang");
+  });
+
+  test("Hunter's Ritual Stone imports onto a weapon", () => {
+    const item = importItem(CRAFTED_DAGGER, "main_hand", EMBELLISHMENT_BONUS_IDS["Hunter's Ritual Stone"]);
+
+    expect(item.effect).toBeTruthy();
+    expect(item.effect.name).toEqual("Hunter's Ritual Stone");
+  });
+
+  test("Darkmoon Sigils resolve from their bare spell name to the full embellishment name", () => {
+    ["Darkmoon Sigil: Hunt", "Darkmoon Sigil: Void", "Darkmoon Sigil: Blood"].forEach((name) => {
+      const item = importItem(CRAFTED_DAGGER, "main_hand", EMBELLISHMENT_BONUS_IDS[name]);
+
+      expect(item.effect).toBeTruthy();
+      expect(item.effect.name).toEqual(name);
+    });
+  });
+
+  test("every imported embellishment name matches an entry in EmbellishmentDB", () => {
+    // A name that doesn't match the DB scores as a flat zero, which is the failure mode this guards against.
+    Object.entries(EMBELLISHMENT_BONUS_IDS).forEach(([name, bonusID]) => {
+      const slot = name.includes("Sigil") || name.includes("Ritual Stone") ? "main_hand" : "chest";
+      const itemID = slot === "main_hand" ? CRAFTED_DAGGER : CRAFTED_MAIL_CHEST;
+      const item = importItem(itemID, slot, bonusID);
+
+      expect(item.effect).toBeTruthy();
+      expect(embellishmentDB.some((embel) => embel.effect.name === item.effect.name)).toBe(true);
+    });
+  });
+
+  test("a crafted item with no embellishment bonus ID imports without an effect", () => {
+    const line = `chest=,id=${CRAFTED_MAIL_CHEST},bonus_id=12052,crafted_stats=36/49,crafting_quality=5`;
+    const item = processItem(line, player, "Raid", "", settings, false, false);
+
+    expect(item).toBeTruthy();
+    expect(item.effect).toBeFalsy();
+  });
+});

--- a/src/General/Items/GearImport/SimCImportEngine.ts
+++ b/src/General/Items/GearImport/SimCImportEngine.ts
@@ -7,6 +7,7 @@ import { CONSTANTS } from "General/Engine/CONSTANTS";
 import { getTitanDiscName } from "Retail/Engine/EffectFormulas/Generic/PatchEffectItems/TitanDiscBeltData"
 import ItemSquishEras from "Retail/Engine/ItemSquishEras.json"
 import { bonusLootCaches } from "Databases/InstanceDB";
+import { getEmbellishmentByEffectName } from "Databases/EmbellishmentDB";
 
 /**
  * This entire page is a bit of a disaster, owing mostly to how bizarrely some things are implemented in game. 
@@ -19,6 +20,18 @@ const stat_ids: {[key: number]: string} = {
   32: "crit",
   40: "versatility",
   49: "mastery",
+};
+
+// SimC gives us the spell name for Darkmoon Sigils, which is only the suffix ("Hunt", "Void" and so on).
+// Map those back to the full embellishment name before we look them up.
+const DARKMOON_SIGIL_SPELLS: {[key: string]: string} = {
+  "Ascendance": "Darkmoon Sigil: Ascension",
+  "Symbiosis": "Darkmoon Sigil: Symbiosis",
+  "Vivacity": "Darkmoon Sigil: Vivacity",
+  "Hunt": "Darkmoon Sigil: Hunt",
+  "Void": "Darkmoon Sigil: Void",
+  "Blood": "Darkmoon Sigil: Blood",
+  "Rot": "Darkmoon Sigil: Rot",
 };
 
 function getPlayerServerName(lines: string[]) {
@@ -613,18 +626,19 @@ export function processItem(line: string, player: Player, contentType: contentTy
 
 
           // Embellishments that require a tag.
-          if (['Blessed Pango Charm', 'Arcanoweave Lining', 'Sunfire Silk Lining', 'Primal Spore Binding', 'Hunt', 'Void', 'Rot', 'Blood'].includes(specialEffectName)) {
-            if (specialEffectName === "Ascendance") specialEffectName = "Darkmoon Sigil: Ascension"
-            else if (specialEffectName === "Symbiosis") specialEffectName = "Darkmoon Sigil: Symbiosis"
-            else if (specialEffectName === 'Hunt') specialEffectName = "Darkmoon Sigil: Hunt"
-            else if (specialEffectName === "Void") specialEffectName = "Darkmoon Sigil: Void"
-            
+          // SimC reports the *spell* name, which for the Darkmoon Sigils is just the suffix. Normalise those first,
+          // then check the result against EmbellishmentDB rather than a hardcoded list - the old allowlist only
+          // covered eight names and silently dropped every other embellishment on import.
+          if (DARKMOON_SIGIL_SPELLS[specialEffectName]) specialEffectName = DARKMOON_SIGIL_SPELLS[specialEffectName];
+
+          const matchedEmbellishment = getEmbellishmentByEffectName(specialEffectName);
+          if (matchedEmbellishment) {
             protoItem.effect = {
               type: "embellishment",
-              name: specialEffectName,
+              name: matchedEmbellishment.effect.name,
               level: protoItem.level //(itemBaseLevel + itemLevelGain),
             }
-            
+
             protoItem.uniqueTag = "embellishment";
           }
 

--- a/src/General/Items/Item.ts
+++ b/src/General/Items/Item.ts
@@ -1,6 +1,7 @@
 import { calcStatsAtLevel, calcStatsAtLevelClassic, getItemAllocations, getItemDB, getItemProp } from "../Engine/ItemUtilities";
 import { CONSTRAINTS, setBounds } from "../Engine/CONSTRAINTS";
 import { CONSTANTS } from "General/Engine/CONSTANTS";
+import { getEmbellishmentForItem } from "Databases/EmbellishmentDB";
 
 // The Item class represents an active item in the app at a specific item level.
 // We'll create them when we import a SimC string, or when an item is added manually.
@@ -77,6 +78,15 @@ export class Item {
 
 
     this.effect = getItemProp(id, "effect", gameType);
+
+    // Some crafted items carry an embellishment inherently rather than having one applied. Those are tracked in
+    // EmbellishmentDB via setItems, which lets us pick them up even when the ItemDB row is missing its effect block
+    // (a recurring gap on newly datamined crafted gear). ItemDB wins if it already has one.
+    if (!this.effect && gameType === "Retail") {
+      const bakedIn = getEmbellishmentForItem(id);
+      if (bakedIn) this.effect = { ...bakedIn.effect };
+    }
+
     this.setID = getItemProp(id, "itemSetId", gameType);
     this.uniqueEquip = getItemProp(catalyzedID ? catalyzedID : id, "uniqueEquip", gameType).toLowerCase();
     this.onUse = (slot === "Trinket" && getItemProp(id, "onUseTrinket", gameType) === true);

--- a/src/General/Modules/ItemBar/ItemBar.js
+++ b/src/General/Modules/ItemBar/ItemBar.js
@@ -19,6 +19,7 @@ import {
   calcStatsAtLevel,
   autoAddItems,
   getItemEffectOptions,
+  hasUnallocatedStats,
 } from "../../Engine/ItemUtilities";
 import { CONSTRAINTS } from "../../Engine/CONSTRAINTS";
 import { useSelector } from "react-redux";
@@ -330,7 +331,9 @@ export default function ItemBar(props) {
     itemLevel: true,
     socket: gameType === "Retail" && CONSTANTS.socketSlots.includes(getItemProp(itemID, "slot", gameType)),
     tertiaries: !(isItemCrafted) && gameType === "Retail",
-    missives: isItemCrafted || getItemProp(itemID, "randomStats", gameType),
+    // Only offer the crafted stat picker when the item actually has stat budget to assign. Generic crafts always
+    // do; fixed-embellished items don't, and showing a picker there implies a choice that has no effect.
+    missives: (isItemCrafted && hasUnallocatedStats(itemID, gameType)) || getItemProp(itemID, "randomStats", gameType),
     specialEffect: itemEffectOptions.length > 0,
   }
 

--- a/src/General/Modules/TopGear/Engine/TopGearEngine.ts
+++ b/src/General/Modules/TopGear/Engine/TopGearEngine.ts
@@ -6,7 +6,8 @@ import { convertPPMToUptime, getSetting, getDiminishedValue } from "../../../../
 import Player from "../../Player/Player";
 import CastModel from "../../Player/CastModel";
 import { getEffectValue } from "../../../../Retail/Engine/EffectFormulas/EffectEngine";
-import { applyDiminishingReturns, getAllyStatsValue, getGemElement, getGems } from "General/Engine/ItemUtilities";
+import { applyDiminishingReturns, getAllyStatsValue, getGemElement, getGems, isEmbellished } from "General/Engine/ItemUtilities";
+import { reportError } from "General/SystemTools/ErrorLogging/ErrorReporting";
 import { getTrinketValue } from "Retail/Engine/EffectFormulas/Generic/Trinkets/TrinketEffectFormulas";
 import { allRamps, allRampsHealing, getDefaultDiscTalents } from "General/Modules/Player/ClassDefaults/DisciplinePriest/DiscRampUtilities";
 import { buildRamp } from "General/Modules/Player/ClassDefaults/DisciplinePriest/DiscRampGen";
@@ -252,6 +253,9 @@ export function runTopGear(rawItemList: Item[], wepCombos: Item[], player: Playe
   let itemSets = createSets(itemList, wepCombos, player.spec);
   let resultSets = [];
 
+  // Tracked so the report can explain why a selected embellished item never shows up in a set.
+  const embellishedSelected = itemList.filter((item: Item) => isEmbellished(item)).length;
+
   itemSets.sort((a, b) => (a.sumSoftScore < b.sumSoftScore ? 1 : -1));
   
   // == Evaluate Sets ==
@@ -295,10 +299,16 @@ export function runTopGear(rawItemList: Item[], wepCombos: Item[], player: Playe
   // If we were able to make a set then create a Top Gear result and return it.
   // If not we'll send back an empty set which will show an error to the player. That's pretty rare nowadays but can happen if their SimC has empty slots in it and so on.
   if (resultSets.length === 0) {
+    // Every set we built was thrown out. By far the most common cause is the embellishment cap: a player who already
+    // wears two embellishments and then adds a third embellished item has no wearable combination left, and used to
+    // just get an empty report with no explanation.
+    reportError(newPlayer, "Top Gear", "No valid sets after verification. Sets built: " + itemSets.length +
+                ", embellished items selected: " + embellishedSelected, contentType);
     return null;
   } else {
     let result: TopGearResult = new TopGearResult(resultSets[0], differentials, contentType);
     result.itemsCompared = resultSets.length;
+    result.embellishedSelected = embellishedSelected;
     result.new = true;
     result.id = generateReportCode();
     return result;
@@ -753,7 +763,10 @@ function evalSet(rawItemSet: ItemSet, player: Player, contentType: contentTypes,
   const consumableStats: Stats = {};
   // == Flask ==
   let selectedChoice = "";
-  if (getSetting(userSettings, "flaskChoice") === "Automatic") {
+  // getSetting returns 0 when the setting is missing (stale local storage, an engine test that passes a partial
+  // settings object), so treat anything that isn't a usable string as Automatic rather than crashing the whole run.
+  const flaskChoice = getSetting(userSettings, "flaskChoice");
+  if (typeof flaskChoice !== "string" || !flaskChoice || flaskChoice === "Automatic") {
     const bestStat = getHighestWeight(castModel);
 
     if ((setStats[bestStat] + bonus_stats[bestStat]) > 28000) {
@@ -763,7 +776,7 @@ function evalSet(rawItemSet: ItemSet, player: Player, contentType: contentTypes,
     selectedChoice = bestStat;
   }
   else {
-    selectedChoice = getSetting(userSettings, "flaskChoice").toLowerCase();
+    selectedChoice = flaskChoice.toLowerCase();
     consumableStats[selectedChoice]  = (consumableStats[selectedChoice] || 0) + 165;
   }
 

--- a/src/General/Modules/TopGear/Engine/TopGearEngineShared.js
+++ b/src/General/Modules/TopGear/Engine/TopGearEngineShared.js
@@ -5,10 +5,6 @@ import { CONSTANTS } from "General/Engine/CONSTANTS";
 import { getTranslatedSlotName } from "locale/slotsLocale";
 import { getSetting } from "Retail/Engine/EffectFormulas/EffectUtilities";
 
-export function createTopGearWorker() {
-  return new Worker(new URL('./TopGearWorker.js', import.meta.url), { type: 'module' });
-}
-
 // Compiles stats & bonus stats into one array to which we can then apply DR etc. 
 export function compileStats(stats, bonus_stats) {
 

--- a/src/General/Modules/TopGear/Engine/TopGearResult.ts
+++ b/src/General/Modules/TopGear/Engine/TopGearResult.ts
@@ -13,6 +13,10 @@ export class TopGearResult {
   itemsCompared: number =  0;
   id: string = "";
   new: boolean = false;
+
+  // How many of the items the player selected carry an embellishment. Only two can be worn at once, so when this is
+  // higher the report explains why a selected embellished item didn't make the final set.
+  embellishedSelected: number = 0;
 }
 
 export default TopGearResult;

--- a/src/General/Modules/TopGear/Engine/TopGearWorkerFactory.js
+++ b/src/General/Modules/TopGear/Engine/TopGearWorkerFactory.js
@@ -1,0 +1,6 @@
+// Spawning the Top Gear worker lives in its own module because `import.meta.url` can only be parsed by the webpack
+// build. Keeping it out of TopGearEngineShared means the engine helpers in that file stay importable from tests,
+// which otherwise fail to parse the whole module before running a single assertion.
+export function createTopGearWorker() {
+  return new Worker(new URL('./TopGearWorker.js', import.meta.url), { type: 'module' });
+}

--- a/src/General/Modules/TopGear/ItemSet.ts
+++ b/src/General/Modules/TopGear/ItemSet.ts
@@ -1,6 +1,7 @@
 // Represents a full set of items.
 import { getTranslatedItemName } from "../../Engine/ItemUtilities";
 import Item from "../../Items/Item";
+import { getEmbellishmentByEffectName } from "Databases/EmbellishmentDB";
 
 
 class ItemSet {
@@ -132,7 +133,8 @@ class ItemSet {
     //console.log("Compiling Stats for Item List of legnth: " + this.itemList.length);
     let setStats =  this.getStartingStats(gameType)
     let setSockets = 0;
-    
+    const multiPieceEmbellishments: { [key: string]: { count: number; effect: any; pieces: number } } = {};
+
     if (gameType === "Classic") {
       // Replace every item with a duplicate.
       this.itemList = this.itemList.map(item => JSON.parse(JSON.stringify(item)));
@@ -164,20 +166,44 @@ class ItemSet {
 
       }
       if (item.onUse) this.onUseTrinkets.push({name: item.effect.name, level: item.level});
-        
+
       if (item.effect) {
         let effect = item.effect;
         effect.level = item.level;
         if (item.selectedOptions) effect.selectedOptions = item.selectedOptions;
-        this.effectList.push(effect);
+
+        // Multi-piece embellishments (the "(Set)" entries in EmbellishmentDB) are carried by several crafted items
+        // but only grant their effect once, and only once enough pieces are worn. Hold them back and resolve after
+        // the loop so we don't count the same bonus two or three times over.
+        const embelSet = effect.type === "embellishment" ? getEmbellishmentByEffectName(effect.name) : undefined;
+        if (embelSet && (embelSet.pieces || 1) > 1) {
+          const held = multiPieceEmbellishments[effect.name] || { count: 0, effect: effect, pieces: embelSet.pieces || 1 };
+          held.count += 1;
+          // Use the lowest item level of the contributing pieces - the set bonus can't scale off gear you aren't wearing.
+          if ((effect.level || 0) < (held.effect.level || 0)) held.effect = effect;
+          multiPieceEmbellishments[effect.name] = held;
+
+          // A multi-piece embellishment consumes an embellishment slot per piece, same as any other. Most carriers
+          // are already tagged uniqueEquip: "Embellishment" in ItemDB and counted above - only top up the ones that
+          // aren't, so the set still respects the two embellishment cap.
+          if (!item.uniqueEquip) this.uniques["embellishment"] = (this.uniques["embellishment"] || 0) + 1;
+        }
+        else {
+          this.effectList.push(effect);
+        }
       }
     }
 
+    // Resolve multi-piece embellishments now that we know how many carriers made it into the set.
+    for (const key in multiPieceEmbellishments) {
+      const held = multiPieceEmbellishments[key];
+      if (held.count >= held.pieces) this.effectList.push(held.effect);
+    }
 
     this.setStats = setStats;
     //this.baseStats = {...setStats};
     this.setSockets = setSockets;
-    
+
     return this;
   }
 

--- a/src/General/Modules/TopGear/Report/DynamicAdvice.ts
+++ b/src/General/Modules/TopGear/Report/DynamicAdvice.ts
@@ -1,6 +1,7 @@
 
 import { Player } from "General/Modules/Player/Player"
 import { Item } from "General/Items/Item"
+import { isEmbellished, MAX_EMBELLISHMENTS } from "General/Engine/ItemUtilities"
 
 const checkHasItem = (itemList: Item[], itemID: number) => {
     return itemList.filter((item: Item) => item.id === itemID).length > 0;
@@ -18,6 +19,25 @@ export const getDynamicAdvice = (report : any, strippedPlayer: any, contentType:
     if (differentials.length === 0 && gameType === "Retail") {
         advice.push("You didn't actually click any extra items which means the set above is what you are currently wearing. You can add items to the comparison \
         by clicking on them in the top gear item select screen.")
+    }
+
+    // A one hander is evaluated with an empty offhand when the player hasn't selected one. That's a real result for
+    // the items they picked, but it costs the one hander a whole item's worth of stats against any two hander it is
+    // being compared to, so say so rather than letting it quietly lose.
+    // Only two embellishments can be worn at once, so any others the player selected are dropped from every set.
+    // Without this the item simply never appears in the report and it looks like Top Gear ignored it.
+    const embellishedInSet = itemList.filter((item: any) => isEmbellished(item)).length;
+    if (report.embellishedSelected > MAX_EMBELLISHMENTS) {
+        advice.push("You selected " + report.embellishedSelected + " embellished items but only " + MAX_EMBELLISHMENTS +
+        " can be worn at once, so the set above uses the best " + embellishedInSet + ". If an embellished item you added \
+        isn't showing up, that's why - deselect one of the others to compare it directly.")
+    }
+
+    const hasOneHander = itemList.some((item: Item) => item.slot === "1H Weapon");
+    const hasOffhand = itemList.some((item: Item) => ["Offhand", "Holdable", "Shield"].includes(item.slot));
+    if (hasOneHander && !hasOffhand) {
+        advice.push("This set uses a one handed weapon but no offhand was selected, so the offhand slot is being scored as empty. \
+        Add an offhand in the item select screen to see what the one hander is really worth.")
     }
     if (gameType === "Classic") {
         advice.push("Expected HPS: " + Math.round(topSet.metrics.healing / 60 * 0.85) + " - " + Math.round(topSet.metrics.healing / 60 * 1) + ". Your HPS can be very fight dependent and it's ok if you aren't perfectly in this range.")

--- a/src/General/Modules/TopGear/TopGear.tsx
+++ b/src/General/Modules/TopGear/TopGear.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import { apiSendTopGearSet } from "../SetupAndMenus/ConnectionUtilities";
 import { Button, Grid, Typography, Divider, Snackbar, SnackbarCloseReason } from "@mui/material";
 import MuiAlert from "@mui/material/Alert";
-import { buildNewWepCombos } from "../../Engine/ItemUtilities";
+import { buildNewWepCombos, getForcedEmbellishmentCount, MAX_EMBELLISHMENTS } from "../../Engine/ItemUtilities";
 import MiniItemCard from "./MiniItemCard";
 import { useHistory } from "react-router-dom";
 import HelpText from "../SetupAndMenus/HelpText";
@@ -26,7 +26,8 @@ import { TopGearResult } from "General/Modules/TopGear/Engine/TopGearResult";
 import TopGearReforgePanel from "./TopGearReforgePanel";
 import { getSetting } from "Retail/Engine/EffectFormulas/EffectUtilities";
 import { prepareTopGear } from "./Engine/TopGearEngineClassic";
-import { buildDifferential, generateReportCode, createTopGearWorker } from "./Engine/TopGearEngineShared";
+import { buildDifferential, generateReportCode } from "./Engine/TopGearEngineShared";
+import { createTopGearWorker } from "./Engine/TopGearWorkerFactory";
 import { trackPageView } from "Analytics";
 import { getVersion } from "../ChangeLog/Log";
 
@@ -36,6 +37,7 @@ type ShortReport = {
   effectList: any[]; // TODO: Replace with proper Effect array.
   differentials: any[]; // TODO: Replace with Differentials.
   contentType: string; // TODO: Replace with contentTypes
+  embellishedSelected?: number; // Drives the "only two embellishments can be worn" note in the report.
   itemSet: {
     itemList: any[]; // TODO: Replace with Item
     setStats: any; // TODO: Replace with nice stat object.
@@ -383,9 +385,17 @@ export default function TopGear(props: any) {
 
       return errorMessage.slice(0, -2);
     }
-    else {
-      return "";
+
+    /* ------------------------------------ Embellishment cap ------------------------------------- */
+    // Only two embellishments can be worn at once. If three or more slots have nothing but embellished items
+    // selected then no wearable set exists, Top Gear discards every set it builds, and the player gets an empty
+    // report with no explanation. Say so on the selection screen instead.
+    const forcedEmbellishments = getForcedEmbellishmentCount(props.player.getSelectedItems());
+    if (forcedEmbellishments > MAX_EMBELLISHMENTS) {
+      return "Too many embellishments (" + forcedEmbellishments + "/" + MAX_EMBELLISHMENTS + "). Add a non-embellished option to one of those slots.";
     }
+
+    return "";
   }
 
   useEffect(() => {
@@ -428,6 +438,7 @@ export default function TopGear(props: any) {
         differentials: report.differentials, 
         new: false,
         contentType: report.contentType,
+        embellishedSelected: report.embellishedSelected,
         effectList: report.itemSet.effectList, 
         
        

--- a/src/Retail/Engine/EffectFormulas/Generic/Embellishments/EmbellishmentData.ts
+++ b/src/Retail/Engine/EffectFormulas/Generic/Embellishments/EmbellishmentData.ts
@@ -350,7 +350,9 @@ export const embellishmentData = [
         runFunc: function(data: Array<effectData>, player: Player, itemLevel: number, additionalData: any) {
             let bonus_stats: Stats = {};
 
-            const enemyType = (getSetting(additionalData.settings, "darkmoonHuntStat") ?? "mastery").toLowerCase();
+            // getSetting returns 0 rather than undefined when a setting is missing, which ?? does not catch.
+            const huntStat = getSetting(additionalData.settings, "darkmoonHuntStat");
+            const enemyType = (typeof huntStat === "string" && huntStat ? huntStat : "mastery").toLowerCase();
 
             bonus_stats[enemyType] = runGenericPPMTrinket({...data[0], stat: enemyType}, itemLevel, additionalData.setStats);
 


### PR DESCRIPTION
First of three, split out of #1787 following review. Independent of the other two.

## Embellishments

Embellishments were driven by three hardcoded lists that had drifted apart from each other and from `EmbellishmentDB`, so items were silently dropped rather than scored:

- **`getItemEffectOptions`** offered seven embellishments and excluded `Finger`/`Neck` outright, so jewellery embellishments could never be attached. Now derived from `EmbellishmentDB` via new `applicable` / `slots` metadata.
- **The SimC importer** matched incoming spell names against an allowlist of eight names and discarded everything else — an imported item lost its embellishment and scored as a plain stat stick, with no error. Now resolves against the same DB. The two entry points also disagreed with each other: `Sunfire Silk Lining` imported but couldn't be added manually, and `Adorned Fang` was the reverse.
- **Crafted items that carry an embellishment inherently** (Axe-Flingin' Bands, the World Tender's set) have no `effect` block in `ItemDB` and simmed as plain gear. `Item` now attaches those from `EmbellishmentDB.setItems`, so a gap in ItemDB can't silently drop them again.
- **Multi-piece embellishment sets** are granted once, only when enough pieces are worn, and consume embellishment slots correctly.
- **Embellishments with no formula** (`Devouring Banding`, `Murder Row Materials`) are flagged `unmodelled` and withheld from the dropdown rather than silently scoring zero. A test fails if a formula lands and the flag isn't removed.
- **The crafted stat picker** is hidden on items with no assignable budget. Generic crafts are all unallocated so this is nearly always shown; it's the fixed-embellished items where a picker implies a choice that has no effect.

## Weapons

`buildNewWepCombos` only emitted a one-hander when it could pair it with an offhand. With no offhand the weapon was invisible to Top Gear — and if it was the player's only weapon there were zero combos, zero sets, and an empty report. Unpaired one-handers are now offered alone, with report advice noting the offhand slot is scored as empty.

## Embellishment cap

Exceeding two embellishments makes every set fail `verifySet`. That's correct, but it was silent: the offending item was dropped from every result, or the whole report came back empty with no explanation. The **selection screen** now warns when the cap makes a set impossible, the report explains when a selected embellished item couldn't be used, and the engine reports the error instead of returning a bare `null`.

## Also

Two latent crashes where `getSetting` returns `0` for a missing setting and the result was used as a string — `darkmoonHuntStat` in the Darkmoon Sigil formula, and `flaskChoice`, which would take out an entire Top Gear run on stale settings.

`createTopGearWorker` moved into its own module so `TopGearEngineShared` can be imported from tests without tripping over `import.meta`.

## Testing

44 suites / 233 tests passing, production build clean. Adds four suites covering the embellishment DB contract, the SimC import path, weapon combinations, and the embellishment cap.
