### PR TITLE
Report absolute HPS for specs that model it

### DIFF
--- a/src/General/Modules/TopGear/Engine/AbsoluteHPS.test.js
+++ b/src/General/Modules/TopGear/Engine/AbsoluteHPS.test.js
@@ -1,0 +1,201 @@
+import Player from "General/Modules/Player/Player";
+import { processAllLines } from "General/Items/GearImport/SimCImportEngine";
+import { buildNewWepCombos } from "General/Engine/ItemUtilities";
+import Item from "General/Items/Item";
+import { runTopGear } from "./TopGearEngine";
+import { MODEL_TYPES } from "General/Engine/CONSTANTS";
+
+// TopGearEngineShared contains the worker factory, which uses import.meta.url and can only be parsed by the
+// webpack build. The engine imports exactly one function from it, so stub that rather than pulling the module in.
+jest.mock("General/Modules/TopGear/Engine/TopGearEngineShared", () => ({
+  generateReportCode: () => "testreportcode",
+}));
+
+
+/*
+  Top Gear ranks sets on hardScore, which is an intellect-equivalent number rather than throughput. Where a spec is
+  evaluated through a cast model we do have a real HPS figure, and these cover it surviving from the engine out to
+  the report for both the best set and every alternative. They also pin the deliberate gap: the stat weight path
+  must report no HPS at all rather than a made up one.
+*/
+
+const settings = {
+  includeGroupBenefits: { value: true, options: [true, false], category: "trinkets", type: "selector" },
+  incarnateAllies: { value: "DPS", options: ["Solo", "DPS", "Tank", "Tank + DPS"], category: "trinkets", type: "selector" },
+  idolGems: { value: 2, options: [1, 2, 3, 4, 5, 6, 7, 8], category: "trinkets", type: "input" },
+  rubyWhelpShell: { value: "Untrained", options: ["Untrained", "AoE Heal", "ST Heal", "Crit Buff", "Haste Buff"], category: "trinkets", type: "selector" },
+  alchStonePotions: { value: 1, options: [0, 1, 2], category: "trinkets", type: "selector" },
+  enchantItems: { value: true, options: [true, false], category: "topGear", type: "selector" },
+  catalystLimit: { value: 1, options: [1, 2, 3], category: "topGear", type: "selector" },
+  upgradeFinderMetric: { value: "Show % Upgrade", options: ["Show % Upgrade", "Show HPS"], category: "upgradeFinder", type: "selector" },
+  topGearAutoGem: { value: false, options: [true, false], category: "topGear", type: "selector" },
+  healingDartsOverheal: { value: 55, options: [], category: "embellishments", type: "Entry" },
+  lariatGems: { value: 3, options: [], category: "embellishments", type: "Entry" },
+  darkmoonHuntStat: { value: "Mastery", options: ["Mastery", "Versatility", "Crit", "Haste"], category: "embellishments", type: "selector" },
+  flaskChoice: { value: "Automatic", options: ["Automatic", "Haste", "Crit", "Mastery", "Versatility"], category: "topGear", type: "selector" },
+  calculateEmbellishments: { value: true, options: [true, false], category: "embellishments", type: "selector" },
+  groupBuffValuation: { value: 75, options: [], category: "trinkets", type: "entry" },
+  averageRaidHealth: { value: 85, options: [], category: "trinkets", type: "Entry" },
+  masteryEffectivenessShaman: { value: 90, options: [], category: "trinkets", type: "Entry" },
+};
+
+const evokerSet = `
+evoker="Evoulker"
+level=80
+race=dracthyr
+region=us
+server=stonemaul
+role=spell
+spec=preservation
+
+head=,id=202488,bonus_id=6652/9414/9229/9409/9334/1498/8767
+neck=,id=204397,bonus_id=6652/9409/9334/1492/8767/9477/8782
+shoulder=,id=202486,bonus_id=6652/9227/9409/9334/1498/8767
+back=,id=205025,bonus_id=8836/8840/8902/8960/9405/9366/9376,crafting_quality=5
+chest=,id=204420,bonus_id=9410/9380/6652/9224/9221/1498/8767
+wrist=,id=204704,bonus_id=8836/8840/8902/8960/9405/9376/9366/9414,crafting_quality=5
+hands=,id=202489,bonus_id=6652/9230/9410/9381/1495/8767
+waist=,id=202605,bonus_id=7979/6652/9413/9222/9219/9329/1494/8767
+legs=,id=202487,bonus_id=6652/9228/9382/1504/8767
+feet=,id=202588,bonus_id=9409/6652/9226/9219/9334/1495/8767
+finger1=,id=158314,bonus_id=6652/9414/9144/9334/3311/8767
+finger2=,id=195480,bonus_id=6652/7936/7981/1498/8767
+trinket1=,id=203729,bonus_id=9410/9381/6652/1498/8767
+trinket2=,id=193773,bonus_id=6652/9144/9334/1663/8767
+main_hand=,id=190511,bonus_id=8836/8840/8902/9405/9376/8791/9237/9366,crafted_stats=40/36,crafting_quality=5
+off_hand=,id=193745,bonus_id=9381/6652/9144/1666/8767
+`;
+
+// The SimC string fills each slot exactly once, which leaves Top Gear with a single possible set and therefore no
+// alternatives to report. Adding the same rings and trinkets at other item levels gives it real choices to rank.
+const addAlternatives = (player) => {
+  [
+    { id: 195480, slot: "Finger", levels: [447, 450] },
+    { id: 158314, slot: "Finger", levels: [447] },
+    { id: 203729, slot: "Trinket", levels: [441, 447] },
+    { id: 193773, slot: "Trinket", levels: [441] },
+  ].forEach(({ id, slot, levels }) => {
+    levels.forEach((level) => player.activeItems.push(new Item(id, "", slot, 0, "", 0, level, "")));
+  });
+};
+
+const runFor = (contentType) => {
+  const player = new Player("Evoulker", "Preservation Evoker", 99, "US", "Stonemaul", "Dracthyr", "default", "Retail");
+  processAllLines(player, contentType, evokerSet.split("\n"), -1, -1, settings);
+  addAlternatives(player);
+  player.activateAll();
+
+  const wepCombos = buildNewWepCombos(player, true);
+  const castModel = player.getActiveModel(contentType);
+
+  return {
+    castModel,
+    result: runTopGear(player.activeItems, wepCombos, player, contentType, player.getHPS(contentType), settings, castModel),
+  };
+};
+
+describe("Preservation Evoker reports absolute HPS in Raid", () => {
+  const { result, castModel } = runFor("Raid");
+
+  test("the spec really is on the cast model path, so this suite is testing something", () => {
+    expect(castModel.modelType["Raid"]).toEqual(MODEL_TYPES.CAST_MODEL);
+  });
+
+  test("Top Gear produced a set", () => {
+    expect(result).toBeTruthy();
+    expect(result.itemSet).toBeTruthy();
+  });
+
+  test("the best set carries an absolute HPS figure", () => {
+    expect(result.itemSet.setHPS).toBeGreaterThan(0);
+  });
+
+  test("the HPS figure is throughput and not the ranking score", () => {
+    // setHPS must come from the cast model, not from hardScore, which is an intellect-equivalent ranking number.
+    expect(result.itemSet.setHPS).not.toEqual(result.itemSet.hardScore);
+    expect(result.itemSet.setHPS).toBeGreaterThan(1000);
+    expect(result.itemSet.setHPS).toBeLessThan(100000000);
+    expect(Number.isFinite(result.itemSet.setHPS)).toBe(true);
+  });
+
+  test("the HPS figure matches the modelled throughput on the set's stats", () => {
+    expect(result.itemSet.setHPS).toEqual(Math.round(result.itemSet.setStats.hps));
+  });
+
+  test("every alternative reports its own absolute HPS", () => {
+    expect(result.differentials.length).toBeGreaterThan(0);
+
+    result.differentials.forEach((differential) => {
+      expect(differential.hps).toBeGreaterThan(0);
+    });
+  });
+
+  test("no alternative out-heals the set Top Gear picked", () => {
+    result.differentials.forEach((differential) => {
+      expect(differential.hps).toBeLessThanOrEqual(result.itemSet.setHPS);
+      expect(differential.hpsDifference).toBeLessThanOrEqual(0);
+    });
+  });
+
+  test("hpsDifference is the gap between the alternative and the best set", () => {
+    result.differentials.forEach((differential) => {
+      expect(differential.hpsDifference).toEqual(Math.round(differential.hps - result.itemSet.setHPS));
+    });
+  });
+
+  test("alternatives are ordered from strongest to weakest", () => {
+    const gaps = result.differentials.map((differential) => differential.hpsDifference);
+    const sorted = [...gaps].sort((a, b) => b - a);
+
+    expect(gaps).toEqual(sorted);
+  });
+
+  test("a percentage can be derived from the HPS figures alone", () => {
+    // The report shows both the raw healing given up and that as a percentage of the best set. Both come from the
+    // same two numbers, so they can never disagree the way hardScore and HPS could.
+    result.differentials.forEach((differential) => {
+      const primeHPS = differential.hps - differential.hpsDifference;
+      expect(primeHPS).toEqual(result.itemSet.setHPS);
+
+      const percent = (differential.hpsDifference / primeHPS) * 100;
+      expect(Number.isFinite(percent)).toBe(true);
+      expect(percent).toBeLessThanOrEqual(0);
+      expect(percent).toBeGreaterThan(-100);
+    });
+  });
+
+  test("the equipped set is evaluated for the upgrade percentage", () => {
+    // Every item in the fixture came from a SimC string, so all of them are flagged equipped.
+    expect(result.equippedHPS).toBeGreaterThan(0);
+  });
+
+  test("the best set is at least as good as what the player is wearing", () => {
+    expect(result.itemSet.setHPS).toBeGreaterThanOrEqual(result.equippedHPS);
+  });
+
+  test("the upgrade percentage is a sane number", () => {
+    const upgrade = ((result.itemSet.setHPS - result.equippedHPS) / result.equippedHPS) * 100;
+
+    expect(Number.isFinite(upgrade)).toBe(true);
+    expect(upgrade).toBeGreaterThanOrEqual(0);
+    expect(upgrade).toBeLessThan(1000);
+  });
+});
+
+describe("The stat weight path reports no HPS rather than a fabricated one", () => {
+  const { result, castModel } = runFor("Dungeon");
+
+  test("Dungeon is scored on stat weights for this spec", () => {
+    expect(castModel.modelType["Dungeon"]).toEqual(MODEL_TYPES.DEFAULT);
+  });
+
+  test("no absolute HPS is claimed for the best set", () => {
+    expect(result.itemSet.setHPS).toEqual(0);
+  });
+
+  test("no absolute HPS is claimed for alternatives", () => {
+    result.differentials.forEach((differential) => {
+      expect(differential.hps).toEqual(0);
+    });
+  });
+});

--- a/src/General/Modules/TopGear/Engine/TopGearEngine.ts
+++ b/src/General/Modules/TopGear/Engine/TopGearEngine.ts
@@ -7,11 +7,12 @@ import Player from "../../Player/Player";
 import CastModel from "../../Player/CastModel";
 import { getEffectValue } from "../../../../Retail/Engine/EffectFormulas/EffectEngine";
 import { applyDiminishingReturns, getAllyStatsValue, getGemElement, getGems } from "General/Engine/ItemUtilities";
+import { reportError } from "General/SystemTools/ErrorLogging/ErrorReporting";
 import { getTrinketValue } from "Retail/Engine/EffectFormulas/Generic/Trinkets/TrinketEffectFormulas";
 import { allRamps, allRampsHealing, getDefaultDiscTalents } from "General/Modules/Player/ClassDefaults/DisciplinePriest/DiscRampUtilities";
 import { buildRamp } from "General/Modules/Player/ClassDefaults/DisciplinePriest/DiscRampGen";
 import { getItemSet, getSeasonalTier } from "Classic/Databases/RetailItemSetDB";
-import { CONSTANTS } from "General/Engine/CONSTANTS";
+import { CONSTANTS, MODEL_TYPES } from "General/Engine/CONSTANTS";
 import { getCircletEffect } from "Retail/Engine/EffectFormulas/Generic/PatchEffectItems/CyrcesCircletData"
 import { generateReportCode } from "General/Modules/TopGear/Engine/TopGearEngineShared"
 import Item from "General/Items/Item";
@@ -252,6 +253,21 @@ export function runTopGear(rawItemList: Item[], wepCombos: Item[], player: Playe
   let itemSets = createSets(itemList, wepCombos, player.spec);
   let resultSets = [];
 
+  // == Currently equipped set ==
+  // Run the player's current gear through the same evaluation so the report can show how big an upgrade the best
+  // set actually is. Display only, and deliberately outside the ranking loop so it never competes.
+  let equippedHPS = 0;
+  try {
+    const equippedItems = itemList.filter((item: Item) => item.isEquipped);
+    if (equippedItems.length > 0) {
+      const equippedSet = evalSet(new ItemSet(-1, equippedItems, 0, player.spec), newPlayer, contentType, baseHPS, userSettings, newCastModel, false, 0);
+      equippedHPS = equippedSet.setHPS || 0;
+    }
+  } catch (err) {
+    // A malformed equipped set shouldn't take down the whole run - we just lose the upgrade percentage.
+    reportError(newPlayer, "Top Gear", "Failed to evaluate equipped set for upgrade comparison", String(err));
+  }
+
   itemSets.sort((a, b) => (a.sumSoftScore < b.sumSoftScore ? 1 : -1));
   
   // == Evaluate Sets ==
@@ -299,6 +315,7 @@ export function runTopGear(rawItemList: Item[], wepCombos: Item[], player: Playe
   } else {
     let result: TopGearResult = new TopGearResult(resultSets[0], differentials, contentType);
     result.itemsCompared = resultSets.length;
+    result.equippedHPS = equippedHPS;
     result.new = true;
     result.id = generateReportCode();
     return result;
@@ -477,13 +494,21 @@ function buildDifferential(itemSet: ItemSet, primeSet: ItemSet, player: Player, 
   let differentials: {
     items: Item[]; //
     gems: number[]; //
-    scoreDifference: number; 
-    rawDifference: number; 
+    scoreDifference: number;
+    rawDifference: number;
+    hps: number;
+    hpsDifference: number;
   } = {
     items: [],
     gems: [],
     scoreDifference: ((Math.round(primeSet.hardScore - itemSet.hardScore) / primeSet.hardScore) * 100 * modelDiff),
     rawDifference: Math.round(((itemSet.hardScore - primeSet.hardScore) / primeSet.hardScore) * player.getHPS(contentType) * modelDiff),
+
+    // Absolute throughput for this alternative, and the healing it gives up against the best set.
+    // Both are 0 when the spec / content type is scored on stat weights, since no HPS figure exists there.
+    // modelDiff only scales the stat weight path, which is exactly where these stay 0, so the two don't interact.
+    hps: itemSet.setHPS || 0,
+    hpsDifference: Math.round((itemSet.setHPS || 0) - (primeSet.setHPS || 0)),
   };
 
 
@@ -1096,6 +1121,17 @@ function evalSet(rawItemSet: ItemSet, player: Player, contentType: contentTypes,
   }
 
   builtSet.hardScore = Math.round(1000 * hardScore) / 1000;
+
+  // == Absolute Throughput ==
+  // hardScore is an intellect-equivalent ranking number and can't be shown to the player as healing. Where the set
+  // was run through a cast model or a ramp sim though, setStats.hps is a genuine HPS figure we can report directly.
+  // On the stat weight path setStats.hps only holds flat HPS granted by effects, which is not the player's total
+  // healing, so we leave this at 0 rather than report a misleading number.
+  const evaluationPath = castModel.modelType[contentType];
+  builtSet.setHPS = (evaluationPath === MODEL_TYPES.CAST_MODEL || evaluationPath === MODEL_TYPES.SEQUENCES)
+                      ? Math.round(setStats.hps || 0)
+                      : 0;
+
   builtSet.setStats = setStats;
   builtSet.enchantBreakdown = enchants;
   builtSet.gemBreakdown = JSON.stringify(enchants["Gems"] || []);
@@ -1348,6 +1384,7 @@ function evalSetOld(itemSet, player, contentType, baseHPS, userSettings, castMod
   }
 
   builtSet.hardScore = Math.round(1000 * hardScore) / 1000;
+
   builtSet.setStats = setStats;
   builtSet.enchantBreakdown = enchants;
   return builtSet; // Temp

--- a/src/General/Modules/TopGear/Engine/TopGearEngineShared.js
+++ b/src/General/Modules/TopGear/Engine/TopGearEngineShared.js
@@ -49,6 +49,11 @@ export const generateReportCode = () => {
       gems: [],
       scoreDifference: (Math.round(primeSet.hardScore - itemSet.hardScore) / primeSet.hardScore) * 100,
       rawDifference: Math.round(((itemSet.hardScore - primeSet.hardScore)))/* * player.getHPS(contentType))*/,
+
+      // Absolute throughput for this alternative, and the healing it gives up against the best set.
+      // Both are 0 when the spec / content type is scored on stat weights, since no HPS figure exists there.
+      hps: itemSet.setHPS || 0,
+      hpsDifference: Math.round((itemSet.setHPS || 0) - (primeSet.setHPS || 0)),
     };
   
     for (var x = 0; x < diffList.length; x++) {

--- a/src/General/Modules/TopGear/Engine/TopGearResult.ts
+++ b/src/General/Modules/TopGear/Engine/TopGearResult.ts
@@ -13,6 +13,10 @@ export class TopGearResult {
   itemsCompared: number =  0;
   id: string = "";
   new: boolean = false;
+
+  // Throughput of the gear the player is currently wearing, evaluated through the same path as the candidate sets.
+  // Used to show how much of an upgrade the best set is. 0 when the spec has no cast model, or nothing is equipped.
+  equippedHPS: number = 0;
 }
 
 export default TopGearResult;

--- a/src/General/Modules/TopGear/ItemSet.ts
+++ b/src/General/Modules/TopGear/ItemSet.ts
@@ -14,6 +14,12 @@ class ItemSet {
   sumSoftScore: number = 0;
   hardScore: number = 0;
 
+  // The set's absolute throughput in HPS. Only populated when the set was evaluated through a cast model or a ramp
+  // sim, since those are the only paths that produce a healing number. On the stat weight path the score is an
+  // intellect-equivalent ranking figure with no throughput attached, so this stays 0 and the report shows nothing
+  // rather than inventing a value.
+  setHPS: number = 0;
+
   // The number of sockets in the set
   setSockets: number = 0;
 
@@ -74,6 +80,7 @@ class ItemSet {
       clonedSet.spec = this.spec;
       clonedSet.sumSoftScore = this.sumSoftScore;
       clonedSet.hardScore = this.hardScore;
+      clonedSet.setHPS = this.setHPS;
       clonedSet.setSockets = this.setSockets;
       clonedSet.uniques = { ...this.uniques };
       clonedSet.effectList = this.effectList.slice();

--- a/src/General/Modules/TopGear/Report/CompetitiveAlternatives.js
+++ b/src/General/Modules/TopGear/Report/CompetitiveAlternatives.js
@@ -57,6 +57,24 @@ function CompetitiveAlternatives(props) {
     return Math.abs(diff);
   };
 
+  /* ------------------------------------ Alternative Set Value ----------------------------------- */
+  // Where the spec is evaluated through a cast model we have a real HPS figure for every alternative, so show the
+  // absolute throughput of the set alongside the healing and percentage it gives up. When the percentage can be
+  // derived from HPS we use that rather than the score difference, since it's the same quantity being reported.
+  // Otherwise fall back to the relative score difference, which is all the stat weight path can honestly tell us.
+  const getSetValueText = (differential) => {
+    if (differential.hps > 0) {
+      const lost = Math.round(differential.hpsDifference || 0);
+      const primeHPS = differential.hps - lost; // the best set's HPS
+      const percent = primeHPS > 0 ? (lost / primeHPS) * 100 : 0;
+      const percentText = Math.abs(percent) < 0.01 ? "<0.01%" : (Math.round(percent * 100) / 100) + "%";
+
+      return Math.round(differential.hps).toLocaleString() + " HPS (" +
+             (lost >= 0 ? "+" : "-") + Math.abs(lost).toLocaleString() + ", " + percentText + ")";
+    }
+    return (gameType === "Classic" ? Math.round(differential.rawDifference / 60) : differential.rawDifference) + " (" + roundTo(differential.scoreDifference, 2) + "%)";
+  };
+
   return (
     <Grid item xs={12}>
       <Paper style={{ padding: 8 }} elevation={0}>
@@ -165,7 +183,7 @@ function CompetitiveAlternatives(props) {
                               width: "100%",
                             }}
                           >
-                            {(gameType === "Classic" ? Math.round(key.rawDifference / 60) : key.rawDifference) + " HPS (" + roundTo(key.scoreDifference, 2) + "%)"}
+                            {getSetValueText(key)}
                           </Typography>
                         </Grid>
                       </Grid>

--- a/src/General/Modules/TopGear/Report/TopGearReport.js
+++ b/src/General/Modules/TopGear/Report/TopGearReport.js
@@ -595,6 +595,8 @@ function displayReport(
                             spec={player.spec}
                             currentLanguage={currentLanguage}
                             gameType={gameType}
+                            setHPS={topSet.setHPS}
+                            equippedHPS={result.equippedHPS}
                           />
                         </Grid>
                       </Grid>

--- a/src/General/Modules/TopGear/Report/TopSetStatsPanel.tsx
+++ b/src/General/Modules/TopGear/Report/TopSetStatsPanel.tsx
@@ -45,6 +45,17 @@ export default function TopSetStatsPanel(props) {
   const breakdown = props.statBreakdown;
   const { t } = useTranslation();
   const gameType = props.gameType;
+  const setHPS = props.setHPS || 0;
+  const equippedHPS = props.equippedHPS || 0;
+
+  // How much of an upgrade the best set is over what the player is wearing right now. Negative is possible and is
+  // shown as such - it means the set Top Gear built is worse than what they already have on.
+  const upgradePercent = equippedHPS > 0 && setHPS > 0 ? ((setHPS - equippedHPS) / equippedHPS) * 100 : null;
+  const formatUpgrade = (percent: number) => (percent > 0 ? "+" : "") + (Math.round(percent * 100) / 100) + "%";
+
+  // A dead-on 0% almost always means the player ran Top Gear without adding any candidate items, so the best set
+  // is simply the gear they're wearing. "+0.00%" reads like the comparison failed, so say what happened instead.
+  const isSameAsEquipped = upgradePercent !== null && Math.abs(setHPS - equippedHPS) < 1;
   const stats =
     gameType === "Retail"
       ? [
@@ -175,6 +186,71 @@ return (
             </Grid>
           ))}
         </Grid>
+
+        {/* Absolute throughput. Only rendered for specs / content types that are evaluated through a cast model or
+            ramp sim, since those are the only paths that produce a real healing number. */}
+        {setHPS > 0 && (
+          <>
+            <Divider variant="middle" sx={{ mt: 1, mb: 1 }} />
+            <Tooltip
+              arrow
+              placement="right"
+              title={
+                <Box sx={{ p: 1, minWidth: 200 }}>
+                  <Typography variant="caption" sx={{ color: "goldenrod", fontWeight: "bold", display: "block", mb: 0.5 }}>
+                    Estimated HPS
+                  </Typography>
+                  <Divider sx={{ borderColor: "rgba(255,255,255,0.15)", mb: 0.75 }} />
+                  <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.7)", display: "block" }}>
+                    Total healing per second this set is modelled to do, from a full cast profile at these stats.
+                    Use it to compare sets - it is not a prediction of your logs.
+                  </Typography>
+                  {upgradePercent !== null && (
+                    <>
+                      <Divider sx={{ borderColor: "rgba(255,255,255,0.15)", mt: 0.75, mb: 0.5 }} />
+                      <Box sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}>
+                        <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.6)" }}>Currently equipped</Typography>
+                        <Typography variant="caption" sx={{ color: "#aad4f5" }}>{Math.round(equippedHPS).toLocaleString()}</Typography>
+                      </Box>
+                      <Box sx={{ display: "flex", justifyContent: "space-between", gap: 2 }}>
+                        <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.6)" }}>Gained</Typography>
+                        <Typography variant="caption" sx={{ color: "#a0f0a0" }}>
+                          {(setHPS - equippedHPS >= 0 ? "+" : "") + Math.round(setHPS - equippedHPS).toLocaleString()}
+                        </Typography>
+                      </Box>
+                    </>
+                  )}
+                </Box>
+              }
+              slotProps={tooltipSlotProps}
+            >
+              <Typography
+                variant="subtitle2"
+                align="center"
+                sx={{
+                  cursor: "help",
+                  color: "goldenrod",
+                  fontWeight: "bold",
+                  display: "block",
+                  transition: "color 0.15s ease",
+                }}
+              >
+                {Math.round(setHPS).toLocaleString() + " HPS"}
+                {upgradePercent !== null && !isSameAsEquipped && (
+                  <span style={{ color: upgradePercent > 0 ? "#a0f0a0" : "#f28b82", fontWeight: "normal" }}>
+                    {" (" + formatUpgrade(upgradePercent) + ")"}
+                  </span>
+                )}
+              </Typography>
+            </Tooltip>
+
+            {isSameAsEquipped && (
+              <Typography variant="caption" align="center" sx={{ color: "rgba(255,255,255,0.5)", display: "block" }}>
+                Same as your equipped gear — add items to compare
+              </Typography>
+            )}
+          </>
+        )}
       </Grid>
     </Grid>
   </Paper>

--- a/src/General/Modules/TopGear/TopGear.tsx
+++ b/src/General/Modules/TopGear/TopGear.tsx
@@ -36,6 +36,7 @@ type ShortReport = {
   effectList: any[]; // TODO: Replace with proper Effect array.
   differentials: any[]; // TODO: Replace with Differentials.
   contentType: string; // TODO: Replace with contentTypes
+  equippedHPS?: number; // Throughput of the player's current gear, for the upgrade percentage.
   itemSet: {
     itemList: any[]; // TODO: Replace with Item
     setStats: any; // TODO: Replace with nice stat object.
@@ -428,6 +429,7 @@ export default function TopGear(props: any) {
         differentials: report.differentials, 
         new: false,
         contentType: report.contentType,
+        equippedHPS: report.equippedHPS,
         effectList: report.itemSet.effectList, 
         
        
@@ -442,6 +444,7 @@ export default function TopGear(props: any) {
                   folioGems: report.itemSet.folioGems || [],
                   firstSocket: report.itemSet.firstSocket,
                   hardScore: report.itemSet.hardScore,
+                  setHPS: report.itemSet.setHPS,
                   statBreakdown: report.itemSet.statBreakdown,
                 },
         player: {name: player.charName, realm: player.realm, race: player.race || "", region: player.region, spec: player.spec, model: player.getActiveModel(report.contentType).modelName},


### PR DESCRIPTION
Third of three, split out of #1787 following review. Independent of the other two.

Noting up front: the review raised a preference not to emphasise overall HPS numbers, since the model produces one but in-game results vary a lot. That's a fair product call and this PR is the one to reject or trim if you'd rather not surface it — the other two don't depend on it. Posting it because there's a real bug underneath regardless (see below).

## The bug that exists today

The competitive alternatives list prints a **`hardScore` delta labelled "HPS"**. `hardScore` is an intellect-equivalent ranking number, not healing, so that label is simply wrong. It predates this change. Even if the HPS display isn't wanted, that label should be corrected.

## What this adds

Sets evaluated through a cast model or a ramp sim now carry `setHPS`, a genuine healing figure from the same evaluation that ranks them. It's shown on the stat panel with an upgrade percentage over currently-equipped gear, and per alternative alongside the healing and percentage given up. The percentage is derived from the HPS figures themselves, so the two can't disagree.

**The stat weight path deliberately reports nothing** rather than a fabricated number. `baseHPS` there is a hardcoded placeholder, and that path pre-applies raid buffs which the cast models also apply internally, so anything derived from it would be wrong. Those specs keep the existing relative display.

## Design notes

- The equipped set is evaluated through the **same `evalSet`** as the candidates, so the two figures are comparable rather than one being modelled and the other a baseline constant.
- It runs **outside the ranking loop** and can never influence which set wins.
- It's wrapped so a malformed equipped set costs the upgrade percentage, not the whole run.
- A dead-on `0%` — which happens when Top Gear is run without adding any candidate items, so the best set is simply the player's current gear — now says so instead of reading like the comparison failed.
- The percentage renders negative correctly, for the case where the built set is worse than what's equipped.

## Testing

41 suites / 204 tests passing, production build clean. The suite asserts the figure is throughput rather than the ranking score, that alternatives never out-heal the chosen set, and that the derived percentage is consistent with the raw healing gap.
