### PR TITLE
[tuning] 9/1 Mistweaver Tier Set

### DIFF
--- a/src/General/Modules/Player/ClassDefaults/MistweaverMonk/MistweaverCastProfile.ts
+++ b/src/General/Modules/Player/ClassDefaults/MistweaverMonk/MistweaverCastProfile.ts
@@ -187,9 +187,9 @@ const applyTierSet = (playerData: any, castProfile: CastProfile, spellDB: Record
         buffSpellPerc(spellDB["Rushing Wind Kick"], 100, 1); // healing only
 
         if (playerData.tierSets.includes("Mistweaver Monk S2-4")) {
-            // using 0.15 as opposed to 0.2 since procs cannot proc their own reset
+            // using 0.20 as opposed to 0.25 since procs cannot proc their own reset
             const entry = getSelectedKick(castProfile);
-            if (entry) entry.cpm *= 1.15;
+            if (entry) entry.cpm *= 1.20;
         }
     }
 }


### PR DESCRIPTION
Added the 4-set tuning to 25% - discounted to 20% (`25 / 1.25`) since they still cannot proc off of themselves.