### PR TITLE
Add source filters to Upgrades by Slot

### DIFF
--- a/src/General/Modules/UpgradeFinder/Panels/PanelSlots.js
+++ b/src/General/Modules/UpgradeFinder/Panels/PanelSlots.js
@@ -1,44 +1,29 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { rootStyles } from "./PanelStyles";
 import { Typography, Grid } from "@mui/material";
+import ToggleButton from "@mui/material/ToggleButton";
 import ItemUpgradeCard from "./ItemUpgradeCard";
 import "./Panels.css";
 import { useTranslation } from "react-i18next";
-import { getDifferentialByID } from "../../../Engine/ItemUtilities";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { getTranslatedSlotName } from "locale/slotsLocale";
 import UFAccordion from "./ufComponents/ufAccordian";
 import UFAccordionSummary from "./ufComponents/ufAccordianSummary";
+import { DEFAULT_ITEM_TYPES, getSlotItems, getSlotSourceOptions } from "./slotPanelUtils";
 
-function filterItemListBySlot(itemList, slot, itemTypesEnabled) {
-  const excludedInstance = [748, 749, 750, 751, 321, 752];
-  const dropTypes = {
-    "drop": itemTypesEnabled.includes("Drop"),
-    "bonus": itemTypesEnabled.includes("Bonus Roll"),
-    "max": itemTypesEnabled.includes("Upgraded"),
+const loadStoredSources = (availableSources) => {
+  try {
+    const stored = JSON.parse(sessionStorage.getItem("ufSlotSources"));
+    if (!Array.isArray(stored) || stored.length === 0) {
+      return [...availableSources];
+    }
+    const valid = availableSources.filter((source) => stored.includes(source));
+    return valid.length > 0 ? valid : [...availableSources];
+  } catch (e) {
+    return [...availableSources];
   }
-
-  let temp = itemList.filter(function (item) {
-    if (item.dropType && dropTypes[item.dropType] === false) {
-      return false;
-    }
-
-    if ("source" in item && !excludedInstance.includes(item.source.instanceId) && item.source.encounterId !== 249) {
-      if (slot === "AllMainhands") {
-        return item.slot === "1H Weapon" || item.slot === "2H Weapon";
-      } else if (slot === "Offhands") {
-        return item.slot === "Holdable" || item.slot === "Offhand" || item.slot === "Shield";
-      } else {
-        return item.slot === slot;
-      }
-    } else {
-      return false;
-    }
-  });
-
-  return temp;
-}
+};
 
 export default function SlotsContainer(props) {
   const classes = rootStyles();
@@ -46,10 +31,20 @@ export default function SlotsContainer(props) {
   const currentLanguage = i18n.language;
   const itemDifferentials = props.itemDifferentials;
   const spec = props.spec;
-  const itemTypesEnabled = props.playerSettings.itemTypes
-  console.log(itemDifferentials);
+  const gameType = props.gameType || "Retail";
+  const itemTypesEnabled = props.playerSettings.itemTypes || DEFAULT_ITEM_TYPES;
+  const availableSources = getSlotSourceOptions(gameType);
+  const [sourcesEnabled, setSourcesEnabled] = useState(() => loadStoredSources(availableSources));
 
-  itemDifferentials.sort((a, b) => (a.score < b.score ? 1 : -1));
+  useEffect(() => {
+    sessionStorage.setItem("ufSlotSources", JSON.stringify(sourcesEnabled));
+  }, [sourcesEnabled]);
+
+  const toggleSource = (source) => {
+    setSourcesEnabled((current) =>
+      current.includes(source) ? current.filter((entry) => entry !== source) : [...current, source]
+    );
+  };
 
   const slotList = [
     { slot: "Head", label: "head" },
@@ -68,8 +63,8 @@ export default function SlotsContainer(props) {
     { slot: "Offhands", label: "offhands" },
   ];
 
-  const iconReturn = (slot, spec) => {
-    switch (spec) {
+  const iconReturn = (slot, playerSpec) => {
+    switch (playerSpec) {
       case "Restoration Druid":
       case "Restoration Druid Classic":
         return require("Images/UpgradeFinderIcons/Leather/" + slot + ".jpg");
@@ -92,34 +87,56 @@ export default function SlotsContainer(props) {
         return [-1];
     }
   };
+
   const contentGenerator = () => {
-    return slotList.map((key, i) => (
-      <UFAccordion key={getTranslatedSlotName(key.label, currentLanguage) + "-accordian" + i} elevation={0} style={{ backgroundColor: "rgba(255, 255, 255, 0.12)" }}>
-        <UFAccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls="panel1a-content" id="panel1a-header" style={{ verticalAlign: "middle" }}>
-          <img src={iconReturn(key.slot, spec)} height={30} width={30} style={{ borderRadius: 4, border: "1px solid rgba(255, 255, 255, 0.12)" }} />
-          <Typography align="center" variant="h6" noWrap color="primary">
-            {getTranslatedSlotName(key.label, currentLanguage)} -{" "}
-            {[...filterItemListBySlot(itemDifferentials, key.slot, itemTypesEnabled)].filter((item) => item.score > 0).length} Upgrades
-          </Typography>
-        </UFAccordionSummary>
-        <AccordionDetails style={{ backgroundColor: "#191c23" }}>
-          <Grid xs={12} container spacing={1}>
-            {[...filterItemListBySlot(itemDifferentials, key.slot, itemTypesEnabled)].map((item, index) => (
-              <ItemUpgradeCard key={index} item={item} itemDifferential={getDifferentialByID(itemDifferentials, item.id, item.level)} slotPanel={true} />
-            ))}
-          </Grid>
-        </AccordionDetails>
-      </UFAccordion>
-    ));
+    return slotList.map((key, i) => {
+      const slotItems = getSlotItems(itemDifferentials, key.slot, itemTypesEnabled, sourcesEnabled);
+      const upgradeCount = slotItems.filter((entry) => entry.score > 0).length;
+
+      return (
+        <UFAccordion key={getTranslatedSlotName(key.label, currentLanguage) + "-accordian" + i} elevation={0} style={{ backgroundColor: "rgba(255, 255, 255, 0.12)" }}>
+          <UFAccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls="panel1a-content" id="panel1a-header" style={{ verticalAlign: "middle" }}>
+            <img src={iconReturn(key.slot, spec)} height={30} width={30} style={{ borderRadius: 4, border: "1px solid rgba(255, 255, 255, 0.12)" }} />
+            <Typography align="center" variant="h6" noWrap color="primary">
+              {getTranslatedSlotName(key.label, currentLanguage)} - {upgradeCount} Upgrades
+            </Typography>
+          </UFAccordionSummary>
+          <AccordionDetails style={{ backgroundColor: "#191c23" }}>
+            <Grid container spacing={1}>
+              {slotItems.map((entry) => (
+                <ItemUpgradeCard key={`${entry.item}-${entry.level}-${entry.dropLoc}-${entry.dropType}`} item={entry} slotPanel={true} />
+              ))}
+            </Grid>
+          </AccordionDetails>
+        </UFAccordion>
+      );
+    });
   };
 
   return (
     <div className={classes.root}>
-      <Grid container spacing={1}>
-        <Grid item xs={12}>
-          {contentGenerator()}
-        </Grid>
-      </Grid>
+      <div className={classes.sourceBar}>
+        <Typography variant="h6" color="primary" noWrap>
+          {t("UpgradeFinder.SlotSources")}
+        </Typography>
+        <div className={classes.sourceButtonRow}>
+          {availableSources.map((source) => (
+            <ToggleButton
+              key={source}
+              value={source}
+              selected={sourcesEnabled.includes(source)}
+              onChange={() => toggleSource(source)}
+              classes={{
+                root: classes.sourceToggle,
+                selected: classes.sourceToggleSelected,
+              }}
+            >
+              {t(source, { defaultValue: source })}
+            </ToggleButton>
+          ))}
+        </div>
+      </div>
+      {contentGenerator()}
     </div>
   );
 }

--- a/src/General/Modules/UpgradeFinder/Panels/PanelStyles.js
+++ b/src/General/Modules/UpgradeFinder/Panels/PanelStyles.js
@@ -40,6 +40,51 @@ export const rootStyles = makeStyles((theme) => {
       marginTop: 4,
       padding: 4,
     },
+    sourceBar: {
+      boxSizing: "border-box",
+      width: "100%",
+      display: "flex",
+      alignItems: "center",
+      gap: 12,
+      flexWrap: "wrap",
+      marginBottom: 8,
+      padding: "6px 10px",
+      background: "linear-gradient(180deg, rgba(28, 31, 38, 0.96) 0%, rgba(20, 23, 29, 0.98) 100%)",
+      border: "1px solid rgba(255, 255, 255, 0.12)",
+      borderRadius: 8,
+    },
+    sourceButtonRow: {
+      display: "flex",
+      flex: 1,
+      minWidth: 0,
+      gap: 6,
+    },
+    sourceToggle: {
+      flex: 1,
+      height: 32,
+      borderRadius: 4,
+      border: "1px solid rgba(255, 255, 255, 0.16)",
+      background: "rgba(18, 20, 26, 0.9)",
+      color: "rgba(255, 255, 255, 0.88)",
+      textTransform: "none",
+      fontWeight: 600,
+      fontSize: "0.82rem",
+      "&:hover": {
+        background: "rgba(40, 45, 56, 0.96)",
+        borderColor: "rgba(242, 191, 89, 0.3)",
+      },
+    },
+    sourceToggleSelected: {
+      "&$sourceToggle": {
+        color: "#000",
+        background: "linear-gradient(180deg, rgba(242, 191, 89, 0.98) 0%, rgba(214, 165, 71, 0.98) 100%)",
+        borderColor: "rgba(242, 191, 89, 0.95)",
+      },
+      "&$sourceToggle:hover": {
+        color: "#000",
+        background: "linear-gradient(180deg, rgba(235, 182, 77, 0.98) 0%, rgba(202, 153, 61, 0.98) 100%)",
+      },
+    },
   };
 });
 

--- a/src/General/Modules/UpgradeFinder/Panels/slotPanelUtils.js
+++ b/src/General/Modules/UpgradeFinder/Panels/slotPanelUtils.js
@@ -1,0 +1,55 @@
+export const RETAIL_SLOT_SOURCES = ["Raid", "Dungeon", "Crafted", "Delves"];
+export const CLASSIC_SLOT_SOURCES = ["Raid", "Dungeon"];
+export const DEFAULT_ITEM_TYPES = ["Drop", "Upgraded", "Bonus Roll"];
+
+const ITEM_TYPE_TO_DROP_TYPE = {
+  Drop: "drop",
+  "Bonus Roll": "bonus",
+  Upgraded: "max",
+};
+
+export function getSlotSourceOptions(gameType) {
+  return gameType === "Classic" ? CLASSIC_SLOT_SOURCES : RETAIL_SLOT_SOURCES;
+}
+
+export function filterItemListBySlot(itemList, slot, itemTypesEnabled = DEFAULT_ITEM_TYPES) {
+  const excludedInstance = [748, 749, 750, 751, 321, 752];
+  const enabledDropTypes = new Set(
+    (itemTypesEnabled || DEFAULT_ITEM_TYPES).map((itemType) => ITEM_TYPE_TO_DROP_TYPE[itemType]).filter(Boolean)
+  );
+
+  return itemList.filter((item) => {
+    if (item.dropType && !enabledDropTypes.has(item.dropType)) {
+      return false;
+    }
+
+    if (!("source" in item) || excludedInstance.includes(item.source.instanceId) || item.source.encounterId === 249) {
+      return false;
+    }
+
+    if (slot === "AllMainhands") {
+      return item.slot === "1H Weapon" || item.slot === "2H Weapon";
+    }
+    if (slot === "Offhands") {
+      return item.slot === "Holdable" || item.slot === "Offhand" || item.slot === "Shield";
+    }
+    return item.slot === slot;
+  });
+}
+
+export function filterItemsBySource(itemList, sourcesEnabled) {
+  if (!sourcesEnabled || sourcesEnabled.length === 0) {
+    return [];
+  }
+
+  const enabled = new Set(sourcesEnabled);
+  return itemList.filter((item) => !item.dropLoc || enabled.has(item.dropLoc));
+}
+
+export function getSlotItems(itemList, slot, itemTypesEnabled, sourcesEnabled) {
+  const bySlot = filterItemListBySlot(itemList, slot, itemTypesEnabled);
+  return filterItemsBySource(bySlot, sourcesEnabled).sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return (b.level || 0) - (a.level || 0);
+  });
+}

--- a/src/General/Modules/UpgradeFinder/UpgradeFinderReport.js
+++ b/src/General/Modules/UpgradeFinder/UpgradeFinderReport.js
@@ -27,35 +27,32 @@ function a11yProps(index) {
 }
 
 async function fetchUpgradeReport(reportCode, setResult, setBackgroundImage) {
-  // Check that the reportCode is acceptable.
-  /*const requestOptions = {
-    method: 'GET',
-    mode: 'no-cors',
-    headers: { 'Content-Type': 'application/json' },
-  };*/
+  if (!reportCode || reportCode === "upgradereport") {
+    return;
+  }
 
   const url = "https://questionablyepic.com/api/getUpgradeReport.php?reportID=" + reportCode;
 
   fetch(url)
     .then(res => res.json())
     .then(data => {
-      //console.log(data);
-      if (typeof(data) === "string") {
-        const jsonData = JSON.parse(data);
-        //const img = apiGetPlayerImage3(jsonData.player.name, jsonData.player.realm, jsonData.player.region, setBackgroundImage);
-        setResult(JSON.parse(data))
-        
+      try {
+        if (typeof(data) === "string") {
+          setResult(JSON.parse(data));
+        }
+        else if (typeof(data) === "object"){
+          if ('status' in data && data.status === "Report not found") console.log("INVALID REPORT: " + reportCode);
+        }
+        else {
+          console.error("Invalid Report Data Type");
+        }
+      } catch (e) {
+        console.error("Failed to parse upgrade report", e);
       }
-      else if (typeof(data) === "object"){
-        if ('status' in data && data.status === "Report not found") console.log("INVALID REPORT: " + reportCode);
-      }
-      else {
-        console.error("Invalid Report Data Type");
-      }
-
     })
-
-    //.catch(err => { throw err });
+    .catch((e) => {
+      console.error("Failed to load upgrade report", e);
+    });
 }
 
 
@@ -109,7 +106,8 @@ export default function UpgradeFinderReport(props) {
     }
     else {
       // No result queued. Check URL for report code and load that.
-      fetchUpgradeReport(location.pathname.split("/").pop(), setResult, /*setBackgroundImage*/);
+      const reportCode = (typeof location !== "undefined" ? location.pathname : "").split("/").filter(Boolean).pop();
+      fetchUpgradeReport(reportCode, setResult, /*setBackgroundImage*/);
     }
 
     }, []);
@@ -265,9 +263,7 @@ export default function UpgradeFinderReport(props) {
           <Grid item xs={12}>
             <UFTabPanel value={tabValue} index={gameType === "Retail" ? 4 : 2}>
               <div className={classes.panel}>
-                <Grid container>
-                  <SlotsContainer spec={result.spec} itemList={itemList} itemDifferentials={itemDifferentials} playerSettings={ufSettings} />
-                </Grid>
+                <SlotsContainer spec={result.spec} itemList={itemList} itemDifferentials={itemDifferentials} playerSettings={ufSettings} gameType={gameType} />
               </div>
             </UFTabPanel>
           </Grid>
@@ -365,9 +361,7 @@ export default function UpgradeFinderReport(props) {
           <Grid item xs={12}>
             <UFTabPanel value={tabValue} index={3}>
               <div className={classes.panel}>
-                <Grid container>
-                  <SlotsContainer player={props.player} itemList={itemList} itemDifferentials={itemDifferentials} playerSettings={ufSettings} />
-                </Grid>
+                <SlotsContainer player={props.player} itemList={itemList} itemDifferentials={itemDifferentials} playerSettings={ufSettings} gameType="Classic" />
               </div>
             </UFTabPanel>
           </Grid>

--- a/src/locale/en/translate.json
+++ b/src/locale/en/translate.json
@@ -605,6 +605,7 @@
       "MythicPlus": "Mythic +",
       "PvP": "PvP",
       "UpgradeBySlot": "Upgrades by Slot",
+      "SlotSources": "Sources",
       "WorldBosses": "World Bosses"
     },
     "UpgradeFinderFront": {


### PR DESCRIPTION
Sometimes I think it would be nice to just view the upgrades without certain sources being included.

<img width="1025" height="642" alt="image" src="https://github.com/user-attachments/assets/1d77e6ab-4562-4c0f-b84d-04bc7318ec99" />
<img width="1008" height="572" alt="image" src="https://github.com/user-attachments/assets/ab68e318-6366-4e73-9af4-864da7025cdb" />
